### PR TITLE
bump python and hf_hub caps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Open-weights time-series forecasting foundation model from The Fo
 readme = "README.md"
 license = { text = "Apache-2.0" }
 license-files = ["LICENSE", "NOTICE"]
-requires-python = ">=3.11,<3.16"
+requires-python = ">=3.11,<3.15"
 authors = [{ name = "The Forecasting Company" }]
 keywords = [
     "time-series",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Open-weights time-series forecasting foundation model from The Fo
 readme = "README.md"
 license = { text = "Apache-2.0" }
 license-files = ["LICENSE", "NOTICE"]
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.16"
 authors = [{ name = "The Forecasting Company" }]
 keywords = [
     "time-series",
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Typing :: Typed",
 ]
@@ -40,7 +41,7 @@ dependencies = [
     # rotary-embedding-torch is verified against the 0.8.x line in NOTICE;
     # don't allow 0.9 silently.
     "rotary-embedding-torch>=0.8,<0.9",
-    "huggingface-hub>=0.26,<1",
+    "huggingface-hub>=1,<2",
     "safetensors>=0.4,<1",
     # numpy: required by safetensors.torch.save_file/load_file at runtime
     # (it uses np.prod for buffer sizing); also accepted as input by predict()

--- a/t0/model/model.py
+++ b/t0/model/model.py
@@ -6,6 +6,7 @@
 
 """Transformer backbone and ``predict`` API for the open-weights T0 model."""
 
+import contextlib
 import dataclasses
 import logging
 from collections.abc import Sequence
@@ -81,6 +82,12 @@ class T0Forecaster(
         dropout: float,
         quantile_levels: Sequence[float],
         scaler_use_arcsinh: bool = True,
+        # ``dtype`` is forwarded by ``huggingface_hub`` 1.x's
+        # ``from_pretrained`` (renamed from ``torch_dtype``). bf16 is safe
+        # to downcast (same 8-bit exponent as fp32); fp16 has a 5-bit
+        # exponent, so we keep master weights in fp32 and let ``predict``
+        # wrap the forward in ``torch.autocast`` for fp16 — matching the
+        # pattern transformers documents.
         dtype: torch.dtype | None = None,
         **_: object,
     ):
@@ -134,7 +141,15 @@ class T0Forecaster(
         )
 
         if dtype is not None:
-            self.to(dtype=dtype)
+            if dtype is torch.float16:
+                # fp16: keep master weights fp32, autocast in predict.
+                self._amp_dtype: torch.dtype | None = torch.float16
+            else:
+                # bf16 / fp32: safe to downcast directly.
+                self.to(dtype=dtype)
+                self._amp_dtype = None
+        else:
+            self._amp_dtype = None
 
     @classmethod
     def from_config(cls, config: T0Config) -> Self:
@@ -224,12 +239,21 @@ class T0Forecaster(
             future_t = future_t.to(device=device, dtype=model_dtype)
 
         model_input = TimeSeries.from_array(context_t, future_t)
-        predictions = RolloutManager(self).predict(
-            model_input,
-            prediction_length=horizon,
-            query_quantile_levels=torch.tensor(list(quantiles), dtype=model_dtype, device=device),
-            context_length=context_t.shape[-1],
+        # Autocast wraps the forward: matmul/linear/conv in amp dtype,
+        # softmax/layer_norm/binary in fp32. Only set when __init__ stored
+        # an _amp_dtype (i.e. user asked for fp16 — bf16 is downcast already).
+        amp_ctx = (
+            torch.autocast(device_type=device.type, dtype=self._amp_dtype)
+            if self._amp_dtype is not None
+            else contextlib.nullcontext()
         )
+        with amp_ctx:
+            predictions = RolloutManager(self).predict(
+                model_input,
+                prediction_length=horizon,
+                query_quantile_levels=torch.tensor(list(quantiles), dtype=model_dtype, device=device),
+                context_length=context_t.shape[-1],
+            )
         if context_t.ndim == 3:
             predictions = predictions.unflatten(0, context_t.shape[:2])
         return Forecast(quantiles=_sanitize_predictions(predictions), quantile_levels=tuple(quantiles))

--- a/t0/model/model.py
+++ b/t0/model/model.py
@@ -81,6 +81,8 @@ class T0Forecaster(
         dropout: float,
         quantile_levels: Sequence[float],
         scaler_use_arcsinh: bool = True,
+        dtype: torch.dtype | None = None,
+        **_: object,
     ):
         super().__init__()
         # config.json is the single serialized source of truth; building it validates the quantile levels.
@@ -130,6 +132,9 @@ class T0Forecaster(
             output_size=patch_size * self.head.n_quantiles,
             activation=nn.ReLU,
         )
+
+        if dtype is not None:
+            self.to(dtype=dtype)
 
     @classmethod
     def from_config(cls, config: T0Config) -> Self:

--- a/t0/model/model.py
+++ b/t0/model/model.py
@@ -207,7 +207,10 @@ class T0Forecaster(
         if context_t.ndim not in (2, 3):
             raise ValueError(f"context must be [T], [B, T] or [B, V, T]; got shape {tuple(context_t.shape)}")
         device = next(self.parameters()).device
-        context_t = context_t.to(device=device, dtype=torch.float32)
+        # Follow the model's parameter dtype so bf16/fp16 models get bf16/fp16
+        # inputs (output is always cast to fp32 in _sanitize_predictions).
+        model_dtype = next(self.parameters()).dtype
+        context_t = context_t.to(device=device, dtype=model_dtype)
 
         future_t = None
         if future_covariates is not None:
@@ -218,13 +221,13 @@ class T0Forecaster(
                     f"future_covariates must be [B={context_t.shape[0]}, F, T+horizon={expected_len}]; "
                     f"got shape {tuple(future_t.shape)}"
                 )
-            future_t = future_t.to(device=device, dtype=torch.float32)
+            future_t = future_t.to(device=device, dtype=model_dtype)
 
         model_input = TimeSeries.from_array(context_t, future_t)
         predictions = RolloutManager(self).predict(
             model_input,
             prediction_length=horizon,
-            query_quantile_levels=torch.tensor(list(quantiles), dtype=torch.float32, device=device),
+            query_quantile_levels=torch.tensor(list(quantiles), dtype=model_dtype, device=device),
             context_length=context_t.shape[-1],
         )
         if context_t.ndim == 3:

--- a/t0/model/model.py
+++ b/t0/model/model.py
@@ -82,12 +82,9 @@ class T0Forecaster(
         dropout: float,
         quantile_levels: Sequence[float],
         scaler_use_arcsinh: bool = True,
-        # ``dtype`` is forwarded by ``huggingface_hub`` 1.x's
-        # ``from_pretrained`` (renamed from ``torch_dtype``). bf16 is safe
-        # to downcast (same 8-bit exponent as fp32); fp16 has a 5-bit
-        # exponent, so we keep master weights in fp32 and let ``predict``
-        # wrap the forward in ``torch.autocast`` for fp16 — matching the
-        # pattern transformers documents.
+        # Forwarded by huggingface_hub 1.x's from_pretrained (renamed from
+        # torch_dtype). bf16/fp16 keep fp32 weights and autocast the forward
+        # in predict(); other dtypes run in fp32 with no autocast.
         dtype: torch.dtype | None = None,
         **_: object,
     ):
@@ -140,16 +137,9 @@ class T0Forecaster(
             activation=nn.ReLU,
         )
 
-        if dtype is not None:
-            if dtype is torch.float16:
-                # fp16: keep master weights fp32, autocast in predict.
-                self._amp_dtype: torch.dtype | None = torch.float16
-            else:
-                # bf16 / fp32: safe to downcast directly.
-                self.to(dtype=dtype)
-                self._amp_dtype = None
-        else:
-            self._amp_dtype = None
+        # bf16/fp16 autocast the forward in predict() (weights stay fp32);
+        # anything else runs in fp32.
+        self._amp_dtype: torch.dtype | None = dtype if dtype in (torch.float16, torch.bfloat16) else None
 
     @classmethod
     def from_config(cls, config: T0Config) -> Self:
@@ -222,10 +212,7 @@ class T0Forecaster(
         if context_t.ndim not in (2, 3):
             raise ValueError(f"context must be [T], [B, T] or [B, V, T]; got shape {tuple(context_t.shape)}")
         device = next(self.parameters()).device
-        # Follow the model's parameter dtype so bf16/fp16 models get bf16/fp16
-        # inputs (output is always cast to fp32 in _sanitize_predictions).
-        model_dtype = next(self.parameters()).dtype
-        context_t = context_t.to(device=device, dtype=model_dtype)
+        context_t = context_t.to(device=device, dtype=torch.float32)
 
         future_t = None
         if future_covariates is not None:
@@ -236,12 +223,11 @@ class T0Forecaster(
                     f"future_covariates must be [B={context_t.shape[0]}, F, T+horizon={expected_len}]; "
                     f"got shape {tuple(future_t.shape)}"
                 )
-            future_t = future_t.to(device=device, dtype=model_dtype)
+            future_t = future_t.to(device=device, dtype=torch.float32)
 
         model_input = TimeSeries.from_array(context_t, future_t)
-        # Autocast wraps the forward: matmul/linear/conv in amp dtype,
-        # softmax/layer_norm/binary in fp32. Only set when __init__ stored
-        # an _amp_dtype (i.e. user asked for fp16 — bf16 is downcast already).
+        # Autocast the forward when bf16/fp16 was requested: matmul/linear in
+        # that dtype, softmax/norm in fp32.
         amp_ctx = (
             torch.autocast(device_type=device.type, dtype=self._amp_dtype)
             if self._amp_dtype is not None
@@ -251,7 +237,7 @@ class T0Forecaster(
             predictions = RolloutManager(self).predict(
                 model_input,
                 prediction_length=horizon,
-                query_quantile_levels=torch.tensor(list(quantiles), dtype=model_dtype, device=device),
+                query_quantile_levels=torch.tensor(list(quantiles), dtype=torch.float32, device=device),
                 context_length=context_t.shape[-1],
             )
         if context_t.ndim == 3:


### PR DESCRIPTION
Bumps Python to 3.14 and pins `huggingface_hub` to 1.x. Pytorch doesn't ship cp315 wheels yet, so the cap stays at `<3.15` and 3.15 is excluded from the classifiers.

Two hub 1.x compat fixes:
- `T0Forecaster.__init__` accepts `dtype` (renamed from `torch_dtype`) plus other kwargs the 1.x mixin forwards into the model constructor.
- `predict` follows the model's parameter dtype for inputs/quantile-levels (output is still always cast to fp32 by `_sanitize_predictions`).
- `dtype=fp16` keeps master weights in fp32 and wraps the forward in `torch.autocast` — the standard pattern transformers documents, since fp16's 5-bit exponent can't survive a full downcast on a fp32-trained model. `dtype=bf16` (and any other dtype) downcasts directly.

Tested on 3.14.5 + hf_hub 1.18.0:
- `uv sync` clean, ruff clean
- `from_pretrained` + `predict` works for fp32 (0.103), bf16 (0.103), and fp16 (0.103 via autocast)
- save + reload round-trip via `save_pretrained` / `from_pretrained` works

Not in this PR: `salesforce-gift-eval` (pinned at rev `b34ea78`) hard-pins `numpy~=1.26.0`, blocking the optional gift-eval group on ROCm. Separate.