### PR TITLE
Strip leaked tqdm stderr warning from example notebooks

### DIFF
--- a/notebooks/01_inference_quickstart.ipynb
+++ b/notebooks/01_inference_quickstart.ipynb
@@ -36,16 +36,7 @@
      "shell.execute_reply": "2026-06-15T13:55:44.169680Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/hxiang/CascadeProjects/tfc-t0/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import time\n",
     "import warnings\n",

--- a/notebooks/02_finetune_lora.ipynb
+++ b/notebooks/02_finetune_lora.ipynb
@@ -40,16 +40,7 @@
      "shell.execute_reply": "2026-06-15T13:56:01.623706Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/hxiang/CascadeProjects/tfc-t0/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import time\n",
     "import warnings\n",


### PR DESCRIPTION
## What

Removes the `tqdm` *"IProgress not found"* `stderr` warning that was committed into the output of the **setup cell** in both example notebooks:

- `notebooks/01_inference_quickstart.ipynb`
- `notebooks/02_finetune_lora.ipynb`

The captured warning leaked a local absolute path into version control:

```
/Users/<user>/.../.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found...
```

## Scope

Only the `stderr` stream output on each setup cell is removed (`outputs` → `[]`). All other outputs are intentionally preserved — the inference/forecast plots and the `stdout` training/inference logs are untouched. Source cells are unchanged, so `ruff check .` still passes.

## Note

This warning originates from `tqdm.auto` at import time and isn't caught by the in-notebook `warnings.filterwarnings(...IProgress...)` calls (it fires before/around them). A follow-up could install `ipywidgets` in the `notebooks` extra or import plain `tqdm` to prevent it from reappearing on re-execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `tqdm` "IProgress not found" stderr warning captured in the setup cells of both example notebooks to stop leaking a local absolute path and keep outputs clean.

- **Bug Fixes**
  - Cleared setup cell stderr in `notebooks/01_inference_quickstart.ipynb` and `notebooks/02_finetune_lora.ipynb` by setting `outputs` to `[]`.
  - No source changes; plots and stdout logs are preserved.

<sup>Written for commit c027990a6a161ac6801727debd9a4e56aa8c53c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/theforecastingcompany/tfc-t0/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

