### PR TITLE
docs: fix predict() signature in module docstring and MaskType wording

### DIFF
--- a/t0/__init__.py
+++ b/t0/__init__.py
@@ -3,7 +3,7 @@
 Public API:
     - T0Forecaster — ``nn.Module`` backbone with ``from_pretrained`` /
       ``save_pretrained`` (via ``huggingface_hub.ModelHubMixin``) and the
-      user-facing ``predict(context, horizon, quantiles)``.
+      user-facing ``predict(context, horizon, quantiles, future_covariates)``.
     - Forecast — the value ``predict`` returns (``quantiles`` + ``median``).
     - T0Config — frozen dataclass; ``T0Config.medium()`` for the
       published t0-alpha checkpoint.

--- a/t0/data.py
+++ b/t0/data.py
@@ -18,8 +18,7 @@ class VariateType(IntEnum):
 
 
 class MaskType(IntEnum):
-    """Reason of values for being masked.
-
+    """Reason why a cell value is masked.
 
     ``WITHHELD`` marks cells the model must predict.
     """


### PR DESCRIPTION
## Summary

- `t0/__init__.py`: the module-level docstring listed `predict` as `predict(context, horizon, quantiles)`, but the actual public signature in `T0Forecaster.predict` has a fourth parameter `future_covariates`. Updated the docstring to match.
- `t0/data.py`: the `MaskType` docstring had a spurious double blank line and slightly awkward phrasing. Tightened to "Reason why a cell value is masked."

Both changes are documentation-only with no logic impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects docstrings to match the public API and improve clarity. Updates `t0/__init__.py` to show `predict(context, horizon, quantiles, future_covariates)` and refines `MaskType` wording, removing an extra blank line.

<sup>Written for commit 431210fe9a13a985c1bef2c6331b75fbfd26c859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/theforecastingcompany/tfc-t0/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

