### PR TITLE
docs: link the first-party MLX runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ multiple covariates. `t0-alpha` is our first iteration of the model.
 
 You can use `t0` on [Retrocast](https://app.retrocast.com/), our platform for forecasting on your own data. You can also compare forecast across different open-weight models.
 
+## Choose how to run `t0-alpha`
+
+This package is the first-party PyTorch runtime. The same original checkpoint
+is also available through a first-party MLX runtime and our managed API:
+
+| Use case | Install or open |
+| --- | --- |
+| Local inference with PyTorch | `pip install tfc-t0` |
+| Local inference on Apple silicon with MLX | [`pip install tfc-t0-mlx`](https://pypi.org/project/tfc-t0-mlx/) |
+| Managed inference without local weights | [The Forecasting Company API](https://docs.retrocast.com/documentation/t0-alpha) |
+
+The MLX runtime is inference-only, has a similar `T0Forecaster.predict()` API,
+loads this model's safetensors directly and does not install PyTorch.
+
 ![t0 forecasting French national electricity demand in Retrocast](https://raw.githubusercontent.com/theforecastingcompany/tfc-t0/main/assets/enedis_with_holidays.webp)
 
 _`t0` forecasting French national electricity demand in Retrocast. Data:


### PR DESCRIPTION
## Summary

- add a concise runtime chooser to the existing PyTorch package README
- link the first-party MLX runtime for Apple-silicon inference
- distinguish both local runtimes from the managed Forecasting Company API
- make explicit that MLX loads the same original checkpoint without installing PyTorch

The same README change is included in the canonical navi source in theforecastingcompany/navi#1966 so future public-mirror syncs preserve it.

## Launch coordination

A private review repository exists at https://github.com/theforecastingcompany/tfc-t0-mlx. Keep this PR in draft: review and merge the navi implementation first, then regenerate and review the private mirror. Making it public and publishing the first PyPI release require separate explicit approval.

## Validation

- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/theforecastingcompany/codesmith/tfc-t0/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791018977&installation_model_id=12780&pr_number=7&repository=theforecastingcompany%2Ftfc-t0&return_to=https%3A%2F%2Fgithub.com%2Ftheforecastingcompany%2Ftfc-t0%2Fpull%2F7&signature=a058c835e262a16b100563e52e9818fe33684d1e6ec2daecc92a537783b50f02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runtime chooser to the `t0-alpha` README section so users can pick between the PyTorch package, the new first-party MLX runtime for Apple silicon, and the managed API. The MLX runtime loads the same safetensors checkpoint directly and does not install PyTorch.

Keep this PR in draft until the public `tfc-t0-mlx` repository and PyPI project exist; the new links are the canonical launch URLs.

<sup>Written for commit 5d0d46b7bfde5926bfb518a7b3cc82aa09fbb816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/theforecastingcompany/tfc-t0/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

