### PR TITLE
Add the first-party MLX runtime

### DIFF
--- a/.github/workflows/ci-mlx.yml
+++ b/.github/workflows/ci-mlx.yml
@@ -1,0 +1,61 @@
+name: CI (MLX)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mlx/**"
+      - "t0/**"
+      - "pyproject.toml"
+      - ".github/workflows/ci-mlx.yml"
+      - ".github/workflows/release-mlx.yml"
+  pull_request:
+    paths:
+      - "mlx/**"
+      - "t0/**"
+      - "pyproject.toml"
+      - ".github/workflows/ci-mlx.yml"
+      - ".github/workflows/release-mlx.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    # MLX's macOS wheel requires native Apple silicon and macOS 14 or newer.
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12", "3.14"]
+    defaults:
+      run:
+        working-directory: mlx
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install
+        run: uv sync
+      - name: Lint
+        run: uv run ruff check .
+      - name: Type check
+        run: uv run ty check t0_mlx tools/benchmark.py tools/release.py tools/validate_checkpoint.py
+      - name: Test
+        run: uv run pytest
+      - name: Import smoke
+        run: uv run python -c "from t0_mlx import T0Config, T0Forecaster; print(T0Config.medium())"
+
+  metadata:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mlx
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      - name: Build wheel + sdist
+        run: uv build
+      - name: Check distribution metadata
+        run: uv run --no-project --with "twine==7.0.0" twine check dist/*

--- a/.github/workflows/release-mlx.yml
+++ b/.github/workflows/release-mlx.yml
@@ -1,0 +1,122 @@
+name: Release MLX
+
+on:
+  push:
+    tags: ["tfc-t0-mlx-v*"]
+  # Retry a failed publication by dispatching this workflow from the existing
+  # release tag. Dispatches from a branch fail the source-validation step.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: macos-14
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version_tag: ${{ steps.release.outputs.version_tag }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - name: Verify immutable release source
+        id: release
+        run: |
+          if [[ "$GITHUB_REF" != refs/tags/tfc-t0-mlx-v* ]]; then
+            echo "::error::Run MLX releases from an existing tfc-t0-mlx-v* tag, not $GITHUB_REF" >&2
+            exit 1
+          fi
+          tag="$GITHUB_REF_NAME"
+          version_tag="${tag#tfc-t0-mlx-}"
+          if [ "$(git cat-file -t "refs/tags/$tag")" != tag ]; then
+            echo "::error::$tag must be an annotated tag" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$(git rev-list -n 1 "$tag")" origin/main; then
+            echo "::error::$tag is not on public main" >&2
+            exit 1
+          fi
+          python3 mlx/tools/release.py "$version_tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version_tag=$version_tag" >> "$GITHUB_OUTPUT"
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        working-directory: mlx
+        run: uv sync
+      - name: Lint and type check
+        working-directory: mlx
+        run: |
+          uv run ruff check .
+          uv run ty check t0_mlx tools/benchmark.py tools/release.py tools/validate_checkpoint.py
+      - name: Test release source
+        working-directory: mlx
+        run: uv run pytest
+
+  build:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.verify.outputs.tag }}
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      - name: Build wheel + sdist
+        working-directory: mlx
+        run: uv build
+      - name: Check distribution metadata
+        working-directory: mlx
+        run: uv run --no-project --with "twine==7.0.0" twine check dist/*
+      - name: Preserve reviewed distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tfc-t0-mlx-distributions
+          path: mlx/dist/
+          if-no-files-found: error
+
+  pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download reviewed distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: tfc-t0-mlx-distributions
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+
+  github-release:
+    if: github.event_name == 'push'
+    needs: [verify, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.verify.outputs.tag }}
+      - name: Extract validated release notes
+        run: >-
+          python3 mlx/tools/release.py "${{ needs.verify.outputs.version_tag }}"
+          --notes-output release_notes.md
+      - name: Download reviewed distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: tfc-t0-mlx-distributions
+          path: dist/
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "${{ needs.verify.outputs.tag }}" dist/*
+          --title "tfc-t0-mlx ${{ needs.verify.outputs.version_tag }}"
+          --notes-file release_notes.md
+          --verify-tag

--- a/README.md
+++ b/README.md
@@ -24,19 +24,21 @@ You can use `t0` on [Retrocast](https://app.retrocast.com/), our platform for fo
 
 ## Choose how to run `t0-alpha`
 
-This package is the first-party PyTorch runtime. First-party MLX and ONNX
-options, plus our managed API, are available for other deployment targets:
+This repository contains the first-party PyTorch and MLX runtimes, published
+as separate packages so each installation keeps only its native tensor
+backend. ONNX artifacts and our managed API cover other deployment targets:
 
 | Use case | Install or open |
 | --- | --- |
 | Local inference with PyTorch | `pip install tfc-t0` |
-| Local inference on Apple silicon with MLX | [`pip install tfc-t0-mlx`](https://pypi.org/project/tfc-t0-mlx/) |
+| Local inference on Apple silicon with MLX | [`pip install tfc-t0-mlx`](mlx/) |
 | Accelerator-oriented local and edge inference with ONNX FP16 | [`t0-alpha-onnx-fp16`](https://huggingface.co/theforecastingcompany/t0-alpha-onnx-fp16) |
 | CPU and in-browser inference with ONNX INT8 | [`t0-alpha-onnx-int8`](https://huggingface.co/theforecastingcompany/t0-alpha-onnx-int8) |
 | Managed inference without local weights | [The Forecasting Company API](https://docs.retrocast.com/documentation/t0-alpha) |
 
-The MLX runtime is inference-only, has a similar `T0Forecaster.predict()` API,
-loads this model's safetensors directly and does not install PyTorch.
+The MLX runtime lives in [`mlx/`](mlx/). It is inference-only, has a closely
+matched `T0Forecaster.predict()` API, loads the same safetensors directly, and
+does not install PyTorch.
 
 ![t0 forecasting French national electricity demand in Retrocast](https://raw.githubusercontent.com/theforecastingcompany/tfc-t0/main/assets/enedis_with_holidays.webp)
 

--- a/mlx/BENCHMARKS.md
+++ b/mlx/BENCHMARKS.md
@@ -1,0 +1,102 @@
+# Backend benchmarks
+
+This is a reproducible comparison of the first-party MLX port with the
+first-party PyTorch implementation. Both implementations loaded the same
+original FP32 `model.safetensors`.
+
+## Environment
+
+- Date: 2026-09-04
+- Machine: 14-inch MacBook Pro (2021), Apple M1 Pro, 10 CPU cores
+  (8 performance and 2 efficiency), 16 GB unified memory
+- Operating system: macOS 15.4.1 (24E263)
+- Python: 3.14.3
+- MLX: 0.32.2, default GPU device
+- PyTorch: 2.13.0, MPS and CPU devices, 8 CPU threads
+- Hugging Face revision:
+  `7fbf2648f27133aa427f51d152cdaa35c0268f32`
+- Checkpoint SHA-256:
+  `16c030d3fd70f06dc4238e9a8356e9b5a631d07f80f1bc76ba539991aed5897f`
+- MLX package: `tfc-t0-mlx` 0.1.0a0
+- PyTorch reference package: `tfc-t0` 0.3.0
+
+## Method
+
+Each backend ran in an isolated subprocess. The benchmark exercised the
+public `T0Forecaster.predict()` API with identical NumPy inputs generated from
+seed 0. It performed 10 warm-up forecasts followed by 60 measured forecasts
+for each shape. GPU operations were synchronized inside the timed region.
+The final forecast from every accelerated backend was compared elementwise
+with PyTorch CPU using `rtol=2e-5` and `atol=3e-4`; the command fails if any
+element exceeds that tolerance.
+
+Model loading is excluded. The MLX compiled measurements also exclude the
+shape-dependent compilation and first execution, which are reported
+separately. All measurements use FP32 weights and request the default 0.1,
+0.5, and 0.9 quantiles.
+
+Run the comparison from this directory with the published PyTorch package:
+
+```bash
+uv run --extra parity python tools/benchmark.py /path/to/t0-alpha \
+  --warmup 10 --iterations 60
+```
+
+For local development of both packages, replace `--extra parity` with
+`--with-editable ..`. `--backend`, `--workload`, `--torch-threads`,
+`--parity-rtol`, `--parity-atol`, and `--format json` support narrower or
+machine-readable runs; see `python tools/benchmark.py --help`.
+
+## Results
+
+Steady-state latency in milliseconds:
+
+| Shape | MLX eager | MLX compiled | PyTorch MPS | PyTorch CPU | Compiled MLX vs MPS |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| batch 1, context 96, horizon 32 | 13.86 | **10.73** | 36.18 | 59.19 | **3.37x** |
+| batch 1, context 512, horizon 64 | 14.64 | **10.90** | 39.09 | 74.81 | **3.59x** |
+| batch 8, context 96, horizon 32 | 16.33 | **12.45** | 43.12 | 65.06 | **3.46x** |
+
+Full synchronized timing output:
+
+| Backend | Shape | Minimum | Median | Maximum | Compile + first run | Checksum |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| mlx-eager | batch 1, context 96, horizon 32 | 11.74 ms | 13.86 ms | 20.04 ms | — | 11.805859 |
+| mlx-eager | batch 1, context 512, horizon 64 | 12.78 ms | 14.64 ms | 17.60 ms | — | -20.967939 |
+| mlx-eager | batch 8, context 96, horizon 32 | 13.46 ms | 16.33 ms | 20.45 ms | — | -87.408371 |
+| mlx-compiled | batch 1, context 96, horizon 32 | 9.04 ms | 10.73 ms | 13.75 ms | 149.88 ms | 11.805849 |
+| mlx-compiled | batch 1, context 512, horizon 64 | 9.89 ms | 10.90 ms | 13.92 ms | 22.86 ms | -20.967934 |
+| mlx-compiled | batch 8, context 96, horizon 32 | 11.09 ms | 12.45 ms | 35.40 ms | 28.69 ms | -87.408325 |
+| torch-mps | batch 1, context 96, horizon 32 | 28.85 ms | 36.18 ms | 91.85 ms | — | 11.805881 |
+| torch-mps | batch 1, context 512, horizon 64 | 29.42 ms | 39.09 ms | 57.18 ms | — | -20.967865 |
+| torch-mps | batch 8, context 96, horizon 32 | 32.65 ms | 43.12 ms | 56.11 ms | — | -87.408264 |
+| torch-cpu | batch 1, context 96, horizon 32 | 54.58 ms | 59.19 ms | 88.84 ms | — | 11.805872 |
+| torch-cpu | batch 1, context 512, horizon 64 | 66.56 ms | 74.81 ms | 294.42 ms | — | -20.967855 |
+| torch-cpu | batch 8, context 96, horizon 32 | 58.55 ms | 65.06 ms | 161.00 ms | — | -87.408127 |
+
+The checksums make it easy to spot a different workload. Numerical correctness
+uses the complete elementwise comparisons below and the broader
+checkpoint-backed FP32 parity suite recorded in [`PARITY.md`](PARITY.md).
+
+| Backend | Shape | Maximum absolute error | Maximum relative error | Within tolerance |
+| --- | --- | ---: | ---: | ---: |
+| MLX eager | batch 1, context 96, horizon 32 | 1.788e-6 | 8.574e-5 | yes |
+| MLX eager | batch 1, context 512, horizon 64 | 1.907e-6 | 8.188e-6 | yes |
+| MLX eager | batch 8, context 96, horizon 32 | 2.503e-6 | 1.161e-3 | yes |
+| MLX compiled | batch 1, context 96, horizon 32 | 1.907e-6 | 8.574e-5 | yes |
+| MLX compiled | batch 1, context 512, horizon 64 | 2.146e-6 | 8.545e-6 | yes |
+| MLX compiled | batch 8, context 96, horizon 32 | 2.742e-6 | 1.357e-3 | yes |
+| PyTorch MPS | batch 1, context 96, horizon 32 | 1.073e-6 | 1.102e-4 | yes |
+| PyTorch MPS | batch 1, context 512, horizon 64 | 1.192e-6 | 6.628e-6 | yes |
+| PyTorch MPS | batch 8, context 96, horizon 32 | 2.623e-6 | 5.607e-3 | yes |
+
+## Interpretation
+
+For these short patch-transformer workloads, MLX eager was 2.61–2.67x faster
+than PyTorch MPS. Compiled MLX was 3.37–3.59x faster than PyTorch MPS and
+5.23–6.86x faster than PyTorch CPU.
+
+Compilation is best suited to repeated shapes. Its first-call cost is not part
+of the steady-state comparison and may differ on a cold machine or after a
+framework update. Results are specific to this hardware and software stack;
+other batch sizes, horizons, and Apple chips should be measured independently.

--- a/mlx/CHANGELOG.md
+++ b/mlx/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to `tfc-t0-mlx` are documented here. The format is based
+on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0a0] - 2026-09-04
+
+### Added
+
+- First-party, inference-only MLX implementation of `t0-alpha`.
+- Direct loading of the original `config.json` and `model.safetensors` without
+  rewriting weights.
+- Univariate and multivariate forecasting, typed masks, explicit grouping,
+  known-future covariates, quantile interpolation and autoregressive rollout.
+- Opt-in compilation for repeated input shapes.
+- Checkpoint-backed FP32 parity coverage against the first-party PyTorch
+  implementation.
+- Reproducible comparisons with PyTorch MPS and CPU on Apple silicon.
+- Versioned parity attestations and a protected, tag-bound release pipeline.

--- a/mlx/LICENSE
+++ b/mlx/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 The Forecasting Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mlx/NOTICE
+++ b/mlx/NOTICE
@@ -1,0 +1,16 @@
+T0 for MLX (tfc-t0-mlx)
+Copyright 2026 The Forecasting Company
+
+This product includes software developed at Datadog (https://www.datadoghq.com/),
+Copyright 2025 Datadog, Inc., licensed under the Apache License 2.0.
+Source: https://github.com/DataDog/toto
+
+This product includes software derived from Chronos-2 by Amazon.com, Inc. or
+its affiliates, Copyright Amazon.com, Inc. All Rights Reserved, licensed under
+the Apache License 2.0.
+Source: https://github.com/amazon-science/chronos-forecasting
+
+The rotary position implementation follows the behavior of
+rotary-embedding-torch, Copyright (c) 2020 Phil Wang, licensed under the MIT
+License.
+Source: https://github.com/lucidrains/rotary-embedding-torch

--- a/mlx/PARITY.md
+++ b/mlx/PARITY.md
@@ -1,0 +1,27 @@
+# Numerical parity
+
+Every release of `tfc-t0-mlx` is checked against the first-party PyTorch
+implementation using the original FP32 `t0-alpha` checkpoint. A matching
+versioned entry is required before a release tag can publish.
+
+## [0.1.0a0] - 2026-09-04
+
+- Reference package: `tfc-t0` 0.3.0.
+- Candidate package: `tfc-t0-mlx` 0.1.0a0.
+- Hugging Face revision:
+  `7fbf2648f27133aa427f51d152cdaa35c0268f32`.
+- Checkpoint SHA-256:
+  `16c030d3fd70f06dc4238e9a8356e9b5a631d07f80f1bc76ba539991aed5897f`.
+- Coverage: patch encoding, time and group attention, rotary embeddings,
+  scaling, native and interpolated quantiles, missing observations, ragged
+  padding, explicit groups, known-future covariates, compiled inference and
+  autoregressive rollout.
+- End-to-end tolerance: `rtol=2e-5`, `atol=3e-4` or tighter, depending on the
+  path under test.
+- PyTorch MPS versus CPU: maximum absolute error `2.623e-6` across the three
+  published benchmark workloads; every element passed `rtol=2e-5`,
+  `atol=3e-4`.
+
+The checkpoint itself remains in the gated
+[`theforecastingcompany/t0-alpha`](https://huggingface.co/theforecastingcompany/t0-alpha)
+repository and is not redistributed here.

--- a/mlx/README.md
+++ b/mlx/README.md
@@ -1,0 +1,269 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://www.theforecastingcompany.com/logo/logo_horizontal_dark.png" />
+    <img src="https://www.theforecastingcompany.com/logo/logo_horizontal_light.png" alt="The Forecasting Company" width="280" />
+  </picture>
+</p>
+
+# `t0` for MLX
+
+<p align="center">
+  <a href="https://pypi.org/project/tfc-t0-mlx/"><img src="https://img.shields.io/pypi/v/tfc-t0-mlx" alt="PyPI" /></a>
+  <a href="https://pypi.org/project/tfc-t0-mlx/"><img src="https://img.shields.io/pypi/pyversions/tfc-t0-mlx" alt="Python versions" /></a>
+  <a href="https://github.com/theforecastingcompany/tfc-t0/blob/main/mlx/LICENSE"><img src="https://img.shields.io/pypi/l/tfc-t0-mlx" alt="License" /></a>
+</p>
+
+Open-weights time-series forecasting foundation model from
+[The Forecasting Company](https://theforecastingcompany.com/). `t0` is a
+transformer-based model that produces probabilistic multi-horizon forecasts
+and natively operates on multiple covariates. `t0-alpha` is our first iteration
+of the model.
+
+`tfc-t0-mlx` is the first-party inference runtime optimized for Apple silicon.
+It loads the same original `t0-alpha` safetensors checkpoint as `tfc-t0` and
+does not install PyTorch.
+
+The MLX and PyTorch runtimes are developed together in this repository while
+remaining separate PyPI distributions with independent dependency trees.
+
+You can use `t0` on [Retrocast](https://app.retrocast.com/), our platform for
+forecasting on your own data. You can also compare forecasts across different
+open-weight models.
+
+## Choose how to run `t0-alpha`
+
+| Use case | Install or open |
+| --- | --- |
+| Local inference on Apple silicon with MLX | `pip install tfc-t0-mlx` |
+| Local inference with PyTorch | [`pip install tfc-t0`](https://pypi.org/project/tfc-t0/) |
+| Managed inference without local weights | [The Forecasting Company API](https://docs.retrocast.com/documentation/t0-alpha) |
+
+Both local runtimes load the same model repository and offer a closely matched
+`T0Forecaster.predict()` API. MLX compilation is available as an opt-in
+optimization for repeated input shapes.
+
+![t0 forecasting French national electricity demand in Retrocast](https://raw.githubusercontent.com/theforecastingcompany/tfc-t0/main/assets/enedis_with_holidays.webp)
+
+_`t0` forecasting French national electricity demand in Retrocast. Data:
+[Enedis open data](https://data.enedis.fr/)._
+
+## 📈 Forecasting with covariates
+
+`t0` leverages covariate information, in the past and future when available,
+to improve its forecast.
+
+| Without covariates | With covariates |
+| --- | --- |
+| ![t0 forecast without covariates](https://raw.githubusercontent.com/theforecastingcompany/tfc-t0/main/assets/medicam_without_cov.webp) | ![t0 forecast with covariates](https://raw.githubusercontent.com/theforecastingcompany/tfc-t0/main/assets/medicam_with_cov.webp) |
+
+_Data: [Medic'AM](https://www.assurance-maladie.ameli.fr/etudes-et-donnees/medicaments-classe-atc-medicam),
+monthly drug reimbursements from the French national health insurance._
+
+The [Quickstart](#-quickstart) below shows the API for both a plain univariate
+forecast and a multivariate forecast that conditions on historical and
+known-future covariates.
+
+## 🚀 Quickstart
+
+`tfc-t0-mlx` requires Apple silicon, macOS 14 or newer, and a native arm64
+Python 3.10 or newer. MLX uses the Apple GPU automatically; there is no
+PyTorch-style device selection or `.to("mps")` step.
+
+```bash
+pip install tfc-t0-mlx
+```
+
+The model repository is gated. Accept its terms on
+[Hugging Face](https://huggingface.co/theforecastingcompany/t0-alpha) and run
+`hf auth login` before the first download.
+
+The simplest path is a univariate forecast through `predict`:
+
+```python
+import numpy as np
+from t0_mlx import T0Forecaster
+
+model = T0Forecaster.from_pretrained("theforecastingcompany/t0-alpha").eval()
+
+context = np.random.randn(4, 512).astype(np.float32)  # 4 series, 512 past timesteps
+out = model.predict(context, horizon=64, quantiles=[0.1, 0.5, 0.9])
+out.quantiles.shape  # (4, 64, 3)
+out.median.shape     # (4, 64)
+```
+
+`predict` accepts NumPy and MLX arrays. One-dimensional contexts are
+automatically promoted to a single-row batch. NaN in the context is read as a
+missing observation; to say that some cells are padding instead, pass a `mask`
+— see [batched inference](#batched-inference).
+
+For a shape that will be called repeatedly, compilation is opt-in:
+
+```python
+model.compile()
+out = model.predict(context, horizon=64)
+```
+
+### Forecasting with covariates
+
+Anything you know over the **past** goes in `context` — alongside the target,
+extra variates attend to it and are forecast together. Anything you know over
+the **future** (calendar features, planned promotions, weather forecasts) goes
+in `future_covariates`, shaped `[B, F, context + horizon]`; the model conditions
+on it but does not forecast it.
+
+```python
+import numpy as np
+from t0_mlx import T0Forecaster
+
+model = T0Forecaster.from_pretrained("theforecastingcompany/t0-alpha").eval()
+
+context = np.random.randn(2, 512).astype(np.float32)
+future_covariates = np.random.randn(2, 3, 512 + 64).astype(np.float32)
+
+out = model.predict(
+    context,
+    horizon=64,
+    quantiles=[0.1, 0.5, 0.9],
+    future_covariates=future_covariates,
+)
+out.quantiles.shape  # (2, 64, 3)
+out.median.shape     # (2, 64)
+```
+
+### Batched inference
+
+```python
+import numpy as np
+from t0_mlx import T0Forecaster, batch_series
+
+model = T0Forecaster.from_pretrained("theforecastingcompany/t0-alpha").eval()
+
+daily = np.random.randn(180)    # one series, 180 past timesteps
+store = np.random.randn(2, 96)  # one series of 2 variates, 96 past timesteps
+hourly = np.random.randn(1024)  # one series, 1024 past timesteps
+
+context, mask, group_ids = batch_series([daily, store, hourly])
+context.shape  # (4, 1024) — variates stacked, right-aligned to the longest
+group_ids      # [0, 1, 1, 2] — `store`'s two variates are forecast jointly
+
+out = model.predict(
+    context,
+    horizon=24,
+    quantiles=[0.1, 0.5, 0.9],
+    mask=mask,
+    group_ids=group_ids,
+)
+out.quantiles.shape  # (4, 24, 3)
+out.median[0]        # the 24-step median forecast for `daily`
+```
+
+**For efficient inference at scale, look at
+[Retrocast](https://app.retrocast.com/).**
+
+## 🏗️ Architecture
+
+`t0` is a decoder-style patch transformer that alternates time and covariate
+attention layers. It predicts 5 quantiles (0.1, 0.25, 0.5, 0.75, 0.9), decoding
+multiple horizons in parallel — up to 1024 timesteps in one forward pass — and
+falling back on autoregressive rollout for longer horizons.
+
+|                 |                            |
+| --------------- | -------------------------- |
+| Parameters      | ~102M                      |
+| Layers          | 24                         |
+| Embedding dim   | 512                        |
+| Feedforward dim | 2048                       |
+| Attention heads | 8                          |
+| Patch size      | 32                         |
+| Quantile levels | 0.1, 0.25, 0.5, 0.75, 0.9 |
+
+### Performance
+
+On an Apple M1 Pro, compiled MLX was 2.62–2.91x faster than PyTorch MPS and
+4.83–5.38x faster than PyTorch CPU across three representative workloads. MLX
+eager was 1.97–2.15x faster than PyTorch MPS. These measurements exclude model
+loading and the compiled path's shape-dependent first call.
+
+See the [complete benchmark](BENCHMARKS.md) for the reproducible script,
+environment, methodology, raw timings, and compilation caveats.
+
+### 🧬 Lineage
+
+`t0` builds on ideas — and in places, code — from open-source forecasting
+models. We gratefully acknowledge:
+
+- **Toto** by Datadog ([repo](https://github.com/DataDog/toto)) and
+  **Chronos-2** by Amazon
+  ([repo](https://github.com/amazon-science/chronos-forecasting)) — factorizing
+  attention in the time and variates dimensions.
+- **TiRex** by NXAI
+  ([repo](https://github.com/NX-AI/tirex)) — contiguous patch masking.
+- **rotary-embedding-torch** by Phil Wang
+  ([repo](https://github.com/lucidrains/rotary-embedding-torch)) — rotary
+  position embedding behavior.
+
+Code-level attributions are listed in [`NOTICE`](NOTICE), under their
+respective open-source licenses. This MLX implementation is based on the
+first-party PyTorch architecture and checkpoint.
+
+## 🧰 Public API
+
+The top-level API mirrors `tfc-t0`:
+
+- `T0Forecaster` — MLX `nn.Module` with `from_pretrained`, `save_pretrained`,
+  opt-in `compile` / `uncompile`, and the user-facing `predict(context, horizon,
+  quantiles, future_covariates, mask, group_ids)`.
+- `Forecast` — the object returned by the model.
+- `T0Config` — the configuration of the model; `T0Config.medium()` is the
+  published one.
+- `MaskType` — the reason a time step is masked out, including `PAD` and
+  `MISSING`.
+- `batch_series` — utility to batch time series of potentially different
+  lengths.
+
+The runtime supports univariate and multivariate inputs, missing values,
+explicit groups, known-future covariates, requested-quantile interpolation,
+and arbitrary positive horizons. Forecasts beyond the native 1024-step pass
+continue autoregressively, matching `tfc-t0`.
+
+## Development
+
+From the repository root:
+
+```bash
+cd mlx
+uv sync
+uv run pytest
+uv run ruff check .
+```
+
+To run checkpoint-backed parity tests, point them at a local directory holding
+the original `config.json` and `model.safetensors`. The checked release record
+is in [`PARITY.md`](PARITY.md):
+
+```bash
+T0_MLX_CHECKPOINT=/path/to/t0-alpha uv run --extra parity pytest
+```
+
+The MLX parameter tree has the same tensor names, shapes, dtypes, and
+linear-layer orientation as the original checkpoint, so no numerical weight
+conversion or separate MLX checkpoint is required.
+`tools/validate_checkpoint.py` validates this contract without copying or
+rewriting the weights.
+
+## 📚 Citation
+
+If our model is useful, please use the following citation and star our repo!
+
+```bibtex
+@misc{tfc-t0,
+  title  = {t0: A time-series forecasting foundation model},
+  author = {The Forecasting Company},
+  year   = {2026},
+  url    = {https://huggingface.co/theforecastingcompany/t0-alpha},
+}
+```
+
+## ⚖️ License
+
+Apache-2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).

--- a/mlx/pyproject.toml
+++ b/mlx/pyproject.toml
@@ -1,0 +1,88 @@
+[project]
+name = "tfc-t0-mlx"
+version = "0.1.0a0"
+description = "Open-weights t0-alpha time-series forecasting model for MLX on Apple silicon"
+readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
+requires-python = ">=3.10"
+authors = [{ name = "The Forecasting Company" }]
+keywords = [
+    "t0",
+    "t0-alpha",
+    "time-series",
+    "forecasting",
+    "foundation-model",
+    "transformer",
+    "probabilistic-forecasting",
+    "huggingface",
+    "safetensors",
+    "inference",
+    "mlx",
+    "apple-silicon",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Typing :: Typed",
+]
+dependencies = [
+    "huggingface-hub>=1",
+    "mlx>=0.32.2",
+    "numpy>=1.26",
+    "typing-extensions>=4 ; python_version < '3.11'",
+]
+
+[project.optional-dependencies]
+# The PyTorch implementation is only a development-time parity reference.
+parity = ["tfc-t0>=0.3"]
+
+[project.urls]
+Homepage = "https://huggingface.co/theforecastingcompany/t0-alpha"
+Source = "https://github.com/theforecastingcompany/tfc-t0/tree/main/mlx"
+Issues = "https://github.com/theforecastingcompany/tfc-t0/issues"
+Documentation = "https://huggingface.co/theforecastingcompany/t0-alpha"
+Model = "https://huggingface.co/theforecastingcompany/t0-alpha"
+"Managed API" = "https://docs.retrocast.com/documentation/t0-alpha"
+Benchmarks = "https://github.com/theforecastingcompany/tfc-t0/blob/main/mlx/BENCHMARKS.md"
+Parity = "https://github.com/theforecastingcompany/tfc-t0/blob/main/mlx/PARITY.md"
+Changelog = "https://github.com/theforecastingcompany/tfc-t0/blob/main/mlx/CHANGELOG.md"
+"PyTorch runtime" = "https://pypi.org/project/tfc-t0/"
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "ruff>=0.8",
+    "ty>=0.0.17",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["t0_mlx"]
+
+[tool.uv]
+exclude-newer = "P7D"
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP"]
+ignore = ["E501"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/mlx/t0_mlx/__init__.py
+++ b/mlx/t0_mlx/__init__.py
@@ -1,0 +1,7 @@
+"""Open-weights t0-alpha forecasting model for MLX."""
+
+from t0_mlx.config import T0Config
+from t0_mlx.data import MaskType, batch_series
+from t0_mlx.model import Forecast, T0Forecaster
+
+__all__ = ["Forecast", "MaskType", "T0Config", "T0Forecaster", "batch_series"]

--- a/mlx/t0_mlx/config.py
+++ b/mlx/t0_mlx/config.py
@@ -1,0 +1,108 @@
+"""Architecture configuration for T0Forecaster.
+
+A plain frozen dataclass. ``T0Config.medium()`` returns the hyperparameters of
+the published t0-alpha checkpoint.
+"""
+
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+
+@dataclass(frozen=True)
+class T0Config:
+    """Hyperparameters for an instance of T0Forecaster.
+
+    ``quantile_levels`` must be a non-empty, ascending tuple of unique floats
+    in ``(0, 1)``; use ``T0Config.medium()`` for the published configuration.
+    """
+
+    embed_dim: int
+    num_layers: int
+    num_heads: int
+    mlp_hidden_dim: int
+    patch_size: int
+    group_every_n: int
+    dropout: float
+    quantile_levels: tuple[float, ...]
+    scaler_use_arcsinh: bool = True
+
+    def __post_init__(self) -> None:
+        positive = {
+            "embed_dim": self.embed_dim,
+            "num_layers": self.num_layers,
+            "num_heads": self.num_heads,
+            "mlp_hidden_dim": self.mlp_hidden_dim,
+            "patch_size": self.patch_size,
+        }
+        for name, value in positive.items():
+            if value < 1:
+                raise ValueError(f"{name} must be positive, got {value}")
+        if self.embed_dim % self.num_heads != 0:
+            raise ValueError("embed_dim must be divisible by num_heads")
+        if self.group_every_n > 0 and self.num_layers % self.group_every_n != 0:
+            raise ValueError("group_every_n must divide num_layers")
+        if not 0.0 <= self.dropout < 1.0:
+            raise ValueError(f"dropout must be in [0, 1), got {self.dropout}")
+        if not self.quantile_levels:
+            raise ValueError("quantile_levels must be non-empty")
+        if tuple(sorted(set(self.quantile_levels))) != self.quantile_levels:
+            raise ValueError("quantile_levels must be sorted ascending without duplicates")
+        if any(not 0.0 < level < 1.0 for level in self.quantile_levels):
+            raise ValueError("each quantile level must be in (0, 1)")
+
+    @classmethod
+    def from_dict(cls, values: dict[str, Any]) -> Self:
+        """Construct from the JSON-compatible configuration mapping."""
+        fields = {
+            "embed_dim",
+            "num_layers",
+            "num_heads",
+            "mlp_hidden_dim",
+            "patch_size",
+            "group_every_n",
+            "dropout",
+            "quantile_levels",
+            "scaler_use_arcsinh",
+        }
+        filtered = {key: value for key, value in values.items() if key in fields}
+        if "quantile_levels" in filtered:
+            filtered["quantile_levels"] = tuple(filtered["quantile_levels"])
+        return cls(**filtered)
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> Self:
+        """Load a configuration from `config.json`."""
+        with Path(path).open(encoding="utf-8") as config_file:
+            values = json.load(config_file)
+        if not isinstance(values, dict):
+            raise ValueError("config must contain a JSON object")
+        return cls.from_dict(values)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation."""
+        values = asdict(self)
+        values["quantile_levels"] = list(self.quantile_levels)
+        return values
+
+    @classmethod
+    def medium(cls) -> Self:
+        """Return the published t0-alpha configuration."""
+        return cls(
+            embed_dim=512,
+            num_layers=24,
+            num_heads=8,
+            mlp_hidden_dim=2048,
+            patch_size=32,
+            group_every_n=3,
+            dropout=0.1,
+            quantile_levels=(0.1, 0.25, 0.5, 0.75, 0.9),
+            scaler_use_arcsinh=True,
+        )

--- a/mlx/t0_mlx/data.py
+++ b/mlx/t0_mlx/data.py
@@ -1,0 +1,199 @@
+"""MLX array representation of model inputs."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any
+
+import mlx.core as mx
+
+
+class VariateType(IntEnum):
+    """Role of a variate in the model input."""
+
+    TARGET = 0
+    HISTORICAL = 1
+    FUTURE = 2
+
+
+class MaskType(IntEnum):
+    """Reason that a time step is not an observed value."""
+
+    VALID = 0
+    PAD = 1
+    MISSING = 2
+    CENSORED = 3
+    WITHHELD = 4
+
+
+@dataclass
+class TimeSeries:
+    """Flat variate rows and their per-time-step metadata."""
+
+    variates: mx.array
+    mask: mx.array
+    group_ids: mx.array
+    variate_type: mx.array
+
+    @property
+    def seq_len(self) -> int:
+        return self.variates.shape[1]
+
+    @property
+    def valid_mask(self) -> mx.array:
+        return self.mask == MaskType.VALID
+
+    def time_slice(self, start: int, stop: int) -> "TimeSeries":
+        """Return a half-open slice along the time axis."""
+        return TimeSeries(
+            variates=self.variates[:, start:stop],
+            mask=self.mask[:, start:stop],
+            group_ids=self.group_ids[:, start:stop],
+            variate_type=self.variate_type[:, start:stop],
+        )
+
+    @classmethod
+    def from_context(
+        cls,
+        context: mx.array,
+        mask: mx.array | None = None,
+        group_ids: mx.array | None = None,
+        future_covariates: mx.array | None = None,
+        horizon: int = 0,
+    ) -> "TimeSeries":
+        """Build flat target and optional known-future covariate rows."""
+        if context.ndim == 1:
+            context = context[None, :]
+            if mask is not None and mask.ndim == 1:
+                mask = mask[None, :]
+        if context.ndim not in (2, 3):
+            raise ValueError(f"context must be [T], [B, T] or [B, V, T], got shape {context.shape}")
+        if context.shape[-1] < 1:
+            raise ValueError("context must contain at least one time step")
+
+        batch_size = context.shape[0]
+        n_variates = context.shape[1] if context.ndim == 3 else 1
+        width = context.shape[-1]
+        values = context.reshape(batch_size * n_variates, width)
+        if mask is not None:
+            if mask.shape != context.shape:
+                raise ValueError(f"mask must have the same shape as context {context.shape}, got {mask.shape}")
+            mask = mask.reshape(values.shape)
+
+        is_nan = mx.isnan(values)
+        if mask is None:
+            mask = mx.where(is_nan, MaskType.MISSING, MaskType.VALID).astype(mx.int8)
+        else:
+            mask = mask.astype(mx.int8)
+            if bool(mx.any((mask < MaskType.VALID) | (mask > MaskType.CENSORED)).item()):
+                raise ValueError("mask values must be VALID, PAD, MISSING or CENSORED")
+            if bool(mx.any(is_nan & (mask == MaskType.VALID)).item()):
+                raise ValueError("mask marks NaN cells VALID; mark them MISSING or PAD")
+        values = mx.where(is_nan, mx.array(0.0, dtype=context.dtype), values)
+
+        rows = values.shape[0]
+        if group_ids is None:
+            row_groups = mx.repeat(mx.arange(batch_size, dtype=mx.int32), n_variates)
+        else:
+            if future_covariates is not None:
+                raise ValueError("group_ids cannot be combined with future_covariates")
+            if group_ids.ndim != 1 or group_ids.shape[0] != rows:
+                raise ValueError(f"group_ids must hold one id per target row ({rows}), got {group_ids.shape}")
+            group_ids = group_ids.astype(mx.int32)
+            if bool(mx.any(group_ids < 0).item()):
+                raise ValueError("group_ids must be non-negative")
+            row_groups = group_ids
+        row_groups = row_groups[:, None]
+        group_ids = mx.broadcast_to(row_groups, (rows, width))
+        variate_type = mx.full((rows, width), VariateType.TARGET, dtype=mx.int32)
+        if future_covariates is None:
+            return cls(values, mask, group_ids, variate_type)
+
+        expected_width = width + horizon
+        if (
+            future_covariates.ndim != 3
+            or future_covariates.shape[0] != batch_size
+            or future_covariates.shape[2] != expected_width
+        ):
+            raise ValueError(
+                f"future_covariates must be [B={batch_size}, F, T+horizon={expected_width}], "
+                f"got shape {future_covariates.shape}"
+            )
+        if future_covariates.shape[1] == 0:
+            return cls(values, mask, group_ids, variate_type)
+
+        future_variates = future_covariates.shape[1]
+        future_rows = batch_size * future_variates
+        future_values = future_covariates.reshape(future_rows, expected_width)
+        future_nan = mx.isnan(future_values)
+        future_mask = mx.where(future_nan, MaskType.MISSING, MaskType.VALID).astype(mx.int8)
+        future_values = mx.where(future_nan, mx.array(0.0, dtype=future_values.dtype), future_values)
+        future_groups = mx.repeat(mx.arange(batch_size, dtype=mx.int32), future_variates)[:, None]
+        future_groups = mx.broadcast_to(future_groups, (future_rows, expected_width))
+        future_types = mx.full((future_rows, expected_width), VariateType.FUTURE, dtype=mx.int32)
+
+        target_future_values = mx.zeros((rows, horizon), dtype=values.dtype)
+        target_future_mask = mx.full((rows, horizon), MaskType.WITHHELD, dtype=mx.int8)
+        target_future_groups = mx.broadcast_to(group_ids[:, :1], (rows, horizon))
+        target_future_types = mx.broadcast_to(variate_type[:, :1], (rows, horizon))
+        return cls(
+            variates=mx.concatenate(
+                [mx.concatenate([values, target_future_values], axis=1), future_values],
+                axis=0,
+            ),
+            mask=mx.concatenate(
+                [mx.concatenate([mask, target_future_mask], axis=1), future_mask],
+                axis=0,
+            ),
+            group_ids=mx.concatenate(
+                [mx.concatenate([group_ids, target_future_groups], axis=1), future_groups],
+                axis=0,
+            ),
+            variate_type=mx.concatenate(
+                [mx.concatenate([variate_type, target_future_types], axis=1), future_types],
+                axis=0,
+            ),
+        )
+
+
+def batch_series(series: Sequence[Any]) -> tuple[mx.array, mx.array, mx.array]:
+    """Stack time series of potentially different lengths and variate counts into one model input.
+
+    Each entry is one series, shaped ``(T,)`` or ``(V, T)``. Their variates are
+    stacked along a single ``variates`` axis and right-aligned to the longest
+    entry: cells that only widen a shorter entry are ``PAD``, NaN observations
+    are ``MISSING``, and the returned group ids say which rows came from the
+    same series, so its variates keep attending to one another.
+
+    Raises:
+        ValueError: ``series`` is empty, or an entry is not ``(T,)`` or ``(V, T)``.
+    """
+    entries = [mx.array(entry, dtype=mx.float32) for entry in series]
+    if not entries:
+        raise ValueError("series must hold at least one entry")
+    entries = [entry[None, :] if entry.ndim == 1 else entry for entry in entries]
+    if any(entry.ndim != 2 for entry in entries):
+        raise ValueError("each series must be shaped [T] or [V, T]")
+    if any(entry.shape[-1] < 1 for entry in entries):
+        raise ValueError("each series must contain at least one time step")
+
+    width = max(entry.shape[-1] for entry in entries)
+    contexts = []
+    masks = []
+    groups = []
+    for group, entry in enumerate(entries):
+        pad = width - entry.shape[-1]
+        contexts.append(mx.concatenate([mx.zeros((entry.shape[0], pad), dtype=mx.float32), entry], axis=1))
+        observed_mask = mx.where(mx.isnan(entry), MaskType.MISSING, MaskType.VALID).astype(mx.int8)
+        masks.append(
+            mx.concatenate(
+                [mx.full((entry.shape[0], pad), MaskType.PAD, dtype=mx.int8), observed_mask],
+                axis=1,
+            )
+        )
+        groups.append(mx.full((entry.shape[0],), group, dtype=mx.int32))
+    return (
+        mx.concatenate(contexts, axis=0),
+        mx.concatenate(masks, axis=0),
+        mx.concatenate(groups, axis=0),
+    )

--- a/mlx/t0_mlx/layers.py
+++ b/mlx/t0_mlx/layers.py
@@ -1,0 +1,350 @@
+# Copyright 2026 The Forecasting Company
+# The layer structure follows the first-party t0 PyTorch implementation. Its
+# patched-transformer and rotary backbone is adapted from Datadog's Toto
+# (https://github.com/DataDog/toto); the patch encoding and variate-attention
+# patterns build on Chronos-2
+# (https://github.com/amazon-science/chronos-forecasting).
+# Copyright 2025 Datadog, Inc.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MLX-native leaf layers used by t0-alpha."""
+
+import math
+from collections.abc import Callable, Sequence
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from t0_mlx.data import MaskType, TimeSeries, VariateType
+
+
+class MLP(nn.Module):
+    """Two-layer perceptron with an activation between its projections."""
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        output_size: int,
+        dropout: float = 0.0,
+        activation: Callable[[mx.array], mx.array] = nn.relu,
+    ):
+        super().__init__()
+        self.hidden_layer = nn.Linear(input_size, hidden_size)
+        self.output_layer = nn.Linear(hidden_size, output_size)
+        self.dropout = nn.Dropout(dropout)
+        self.activation = activation
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.output_layer(self.dropout(self.activation(self.hidden_layer(x))))
+
+
+class ResidualBlock(nn.Module):
+    """MLP summed with a learned projection of its input."""
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        output_size: int,
+        dropout: float = 0.0,
+        activation: Callable[[mx.array], mx.array] = nn.relu,
+    ):
+        super().__init__()
+        self.mlp = MLP(input_size, hidden_size, output_size, dropout, activation)
+        self.residual_layer = nn.Linear(input_size, output_size)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.mlp(x) + self.residual_layer(x)
+
+
+class PatchEncoder(nn.Module):
+    """Encode values, within-patch time, validity, and variate role."""
+
+    def __init__(self, embed_dim: int, patch_size: int):
+        super().__init__()
+        self.patch_size = patch_size
+        self.embed_dim = embed_dim
+        self.projection = ResidualBlock(patch_size * 3, embed_dim, embed_dim)
+        self.type_embeddings = nn.Embedding(3, embed_dim)
+
+    def __call__(self, values: mx.array, mask: mx.array, variate_type: mx.array) -> mx.array:
+        if values.ndim != 3 or values.shape[-1] != self.patch_size:
+            raise ValueError(f"values must be [variates, patches, {self.patch_size}]")
+        if mask.shape != values.shape or variate_type.shape != values.shape:
+            raise ValueError("mask and variate_type must match values")
+        total_variates, n_patches, _ = values.shape
+        validity = (mask == 0).astype(values.dtype)
+        time_index = mx.arange(self.patch_size, dtype=values.dtype) / self.patch_size
+        time_index = mx.broadcast_to(time_index, (total_variates, n_patches, self.patch_size))
+        embedded = self.projection(mx.concatenate([values, time_index, validity], axis=-1))
+        type_ids = mx.maximum(variate_type[:, :, 0], mx.array(0, dtype=variate_type.dtype))
+        return embedded + self.type_embeddings(type_ids)
+
+
+class RMSNorm(nn.Module):
+    """RMS normalization with the checkpoint's 1e-8 epsilon."""
+
+    def __init__(self, dims: int, eps: float = 1e-8):
+        super().__init__()
+        self.scale = mx.ones((dims,))
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x * mx.rsqrt(mx.mean(mx.square(x), axis=-1, keepdims=True) + self.eps) * self.scale
+
+
+class SwiGLU(nn.Module):
+    """SwiGLU with the checkpoint's gate-first projection ordering."""
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gate, values = mx.split(x, 2, axis=-1)
+        return nn.silu(gate) * values
+
+
+class QuantileHead(nn.Module):
+    """Turn raw decoder outputs into non-decreasing quantiles."""
+
+    def __init__(self, quantile_levels: Sequence[float]):
+        super().__init__()
+        self.quantile_levels = mx.array(sorted(quantile_levels), dtype=mx.float32)
+
+    @property
+    def n_quantiles(self) -> int:
+        return self.quantile_levels.size
+
+    def __call__(self, x: mx.array) -> mx.array:
+        first = x[..., :1]
+        if x.shape[-1] == 1:
+            return first
+        remaining = first + mx.cumsum(nn.softplus(x[..., 1:]), axis=-1)
+        return mx.concatenate([first, remaining], axis=-1)
+
+
+class Patcher(nn.Module):
+    """Left-pad and reshape time steps into contiguous patches."""
+
+    def __init__(self, patch_size: int):
+        super().__init__()
+        self.patch_size = patch_size
+
+    def pad(self, model_input: TimeSeries) -> TimeSeries:
+        pad_len = (-model_input.seq_len) % self.patch_size
+        if pad_len == 0:
+            return model_input
+        rows = model_input.variates.shape[0]
+        return TimeSeries(
+            variates=mx.concatenate(
+                [mx.zeros((rows, pad_len), dtype=model_input.variates.dtype), model_input.variates], axis=1
+            ),
+            mask=mx.concatenate([mx.full((rows, pad_len), MaskType.PAD, dtype=mx.int8), model_input.mask], axis=1),
+            group_ids=mx.concatenate(
+                [mx.full((rows, pad_len), -1, dtype=model_input.group_ids.dtype), model_input.group_ids], axis=1
+            ),
+            variate_type=mx.concatenate(
+                [mx.full((rows, pad_len), -1, dtype=model_input.variate_type.dtype), model_input.variate_type], axis=1
+            ),
+        )
+
+    def patch(self, values: mx.array) -> mx.array:
+        return values.reshape(*values.shape[:-1], -1, self.patch_size)
+
+
+def _rotate_half(x: mx.array) -> mx.array:
+    paired = x.reshape(*x.shape[:-1], -1, 2)
+    return mx.stack([-paired[..., 1], paired[..., 0]], axis=-1).reshape(x.shape)
+
+
+class TimeAwareRotaryEmbedding:
+    """The checkpoint's temporal RoPE with XPos query/key scaling."""
+
+    def __init__(self, dims: int, theta: float = 10_000.0, scale_base: float = 512.0):
+        self.dims = dims
+        self.theta = theta
+        self.scale_base = scale_base
+
+    def rotate_queries_and_keys(self, queries: mx.array, keys: mx.array) -> tuple[mx.array, mx.array]:
+        seq_len = queries.shape[-2]
+        positions = mx.arange(seq_len, dtype=queries.dtype)
+        frequencies = 1.0 / (self.theta ** (mx.arange(0, self.dims, 2, dtype=mx.float32) / self.dims))
+        angles = mx.repeat(positions[:, None] * frequencies[None, :], 2, axis=-1)
+        cosine = mx.cos(angles)
+        sine = mx.sin(angles)
+
+        scale_frequencies = (mx.arange(0, self.dims, 2, dtype=mx.float32) + 0.4 * self.dims) / (1.4 * self.dims)
+        center = mx.floor(mx.max(positions) / 2.0)
+        power = (positions - center) / self.scale_base
+        half_scale = scale_frequencies[None, :] ** power[:, None]
+        scale = mx.concatenate([half_scale, half_scale], axis=-1).astype(queries.dtype)
+
+        rotated_queries = (queries * cosine + _rotate_half(queries) * sine) * scale
+        rotated_keys = (keys * cosine + _rotate_half(keys) * sine) / scale
+        return rotated_queries.astype(queries.dtype), rotated_keys.astype(keys.dtype)
+
+
+class SelfAttention(nn.Module):
+    """Shared QKV projections for temporal and variate-axis attention."""
+
+    def __init__(self, embed_dim: int, num_heads: int, rotary: TimeAwareRotaryEmbedding | None = None):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.rotary = rotary
+        self.wQKV = nn.Linear(embed_dim, embed_dim * 3)
+        self.wO = nn.Linear(embed_dim, embed_dim)
+        self.q_norm = RMSNorm(self.head_dim)
+        self.k_norm = RMSNorm(self.head_dim)
+
+    def __call__(self, x: mx.array, attn_mask: mx.array) -> mx.array:
+        batch, seq_len, _ = x.shape
+        qkv = self.wQKV(x).reshape(batch, seq_len, 3, self.num_heads, self.head_dim)
+        qkv = qkv.transpose(2, 0, 3, 1, 4)
+        queries, keys, values = qkv[0], qkv[1], qkv[2]
+        queries, keys = self.q_norm(queries), self.k_norm(keys)
+        if self.rotary is not None:
+            queries, keys = self.rotary.rotate_queries_and_keys(queries, keys)
+        attended = mx.fast.scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            scale=1.0 / math.sqrt(self.head_dim),
+            mask=attn_mask,
+        )
+        return self.wO(attended.transpose(0, 2, 1, 3).reshape(batch, seq_len, self.embed_dim))
+
+
+class TimeSelfAttentionBlock(nn.Module):
+    """Pre-norm time-axis attention with a residual connection."""
+
+    def __init__(self, embed_dim: int, num_heads: int, dropout: float, rotary: TimeAwareRotaryEmbedding):
+        super().__init__()
+        self.norm = RMSNorm(embed_dim)
+        self.attention = SelfAttention(embed_dim, num_heads, rotary)
+        self.dropout = nn.Dropout(dropout)
+
+    def __call__(self, x: mx.array, attn_mask: mx.array) -> mx.array:
+        return x + self.dropout(self.attention(self.norm(x), attn_mask))
+
+
+class VariateSelfAttentionBlock(nn.Module):
+    """Pre-norm variate-axis attention with a residual connection."""
+
+    def __init__(self, embed_dim: int, num_heads: int, dropout: float):
+        super().__init__()
+        self.norm = RMSNorm(embed_dim)
+        self.attention = SelfAttention(embed_dim, num_heads)
+        self.dropout = nn.Dropout(dropout)
+
+    def __call__(self, x: mx.array, attn_mask: mx.array) -> mx.array:
+        flipped = x.transpose(1, 0, 2)
+        attended = self.attention(self.norm(flipped), attn_mask)
+        return x + self.dropout(attended).transpose(1, 0, 2)
+
+
+class TransformerLayer(nn.Module):
+    """One attention block followed by a pre-norm SwiGLU feed-forward."""
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        mlp_hidden_dim: int,
+        dropout: float,
+        is_group: bool,
+        rotary: TimeAwareRotaryEmbedding,
+    ):
+        super().__init__()
+        self.is_group = is_group
+        if is_group:
+            self.attention_block = VariateSelfAttentionBlock(embed_dim, num_heads, dropout)
+        else:
+            self.attention_block = TimeSelfAttentionBlock(embed_dim, num_heads, dropout, rotary)
+        self.norm = RMSNorm(embed_dim)
+        self.mlp = [
+            nn.Linear(embed_dim, 2 * mlp_hidden_dim),
+            SwiGLU(),
+            nn.Linear(mlp_hidden_dim, embed_dim),
+            nn.Dropout(dropout),
+        ]
+
+    def __call__(self, x: mx.array, time_mask: mx.array, group_mask: mx.array) -> mx.array:
+        x = self.attention_block(x, group_mask if self.is_group else time_mask)
+        residual = self.mlp[0](self.norm(x))
+        residual = self.mlp[1](residual)
+        residual = self.mlp[2](residual)
+        return x + self.mlp[3](residual)
+
+
+def _reduce_patch_metadata(metadata: mx.array, patched_mask: mx.array) -> mx.array:
+    real = patched_mask != MaskType.PAD
+    first_real = mx.argmax(real.astype(mx.int32), axis=-1, keepdims=True)
+    reduced = mx.take_along_axis(metadata, first_real, axis=-1).squeeze(-1)
+    return mx.where(mx.any(real, axis=-1), reduced, mx.array(-1, dtype=metadata.dtype))
+
+
+def _build_attention_masks(
+    patched_group_ids: mx.array, patched_variate_type: mx.array, patched_mask: mx.array
+) -> tuple[mx.array, mx.array]:
+    patch_group_ids = _reduce_patch_metadata(patched_group_ids, patched_mask)
+    patch_variate_type = _reduce_patch_metadata(patched_variate_type, patched_mask)
+    attendable = mx.any(patched_mask != MaskType.PAD, axis=-1)
+
+    valid = patch_group_ids >= 0
+    same_time_document = (
+        (patch_group_ids[:, :, None] == patch_group_ids[:, None, :]) & valid[:, :, None] & valid[:, None, :]
+    )
+    patches = patch_group_ids.shape[1]
+    causal = mx.tril(mx.ones((patches, patches), dtype=mx.bool_), k=0)
+    time_mask = same_time_document & causal[None, :, :]
+    future_query = patch_variate_type == VariateType.FUTURE
+    time_mask = mx.where(future_query[:, :, None], same_time_document, time_mask)
+    time_mask = time_mask & attendable[:, None, :]
+
+    ids_by_patch = patch_group_ids.transpose(1, 0)
+    valid_by_patch = valid.transpose(1, 0)
+    group_mask = (
+        (ids_by_patch[:, :, None] == ids_by_patch[:, None, :]) & valid_by_patch[:, :, None] & valid_by_patch[:, None, :]
+    )
+    return time_mask[:, None, :, :], group_mask[:, None, :, :]
+
+
+class Transformer(nn.Module):
+    """Alternating time- and variate-attention stack."""
+
+    def __init__(
+        self,
+        num_layers: int,
+        embed_dim: int,
+        num_heads: int,
+        mlp_hidden_dim: int,
+        dropout: float,
+        group_every_n: int,
+    ):
+        super().__init__()
+        rotary = TimeAwareRotaryEmbedding(embed_dim // num_heads)
+        self.layers = [
+            TransformerLayer(
+                embed_dim,
+                num_heads,
+                mlp_hidden_dim,
+                dropout,
+                is_group=group_every_n > 0 and (index + 1) % group_every_n == 0,
+                rotary=rotary,
+            )
+            for index in range(num_layers)
+        ]
+        self.out_norm = RMSNorm(embed_dim)
+
+    def __call__(
+        self,
+        x: mx.array,
+        patched_group_ids: mx.array,
+        patched_variate_type: mx.array,
+        patched_mask: mx.array,
+    ) -> mx.array:
+        time_mask, group_mask = _build_attention_masks(patched_group_ids, patched_variate_type, patched_mask)
+        for layer in self.layers:
+            x = layer(x, time_mask, group_mask)
+        return self.out_norm(x)

--- a/mlx/t0_mlx/model.py
+++ b/mlx/t0_mlx/model.py
@@ -1,0 +1,450 @@
+# Copyright 2026 The Forecasting Company
+# The architecture follows the first-party t0 PyTorch implementation, which is
+# inspired by Datadog's Toto patched-transformer backbone
+# (https://github.com/DataDog/toto). The autoregressive quantile rollout follows
+# Chronos-2's inference approach
+# (https://github.com/amazon-science/chronos-forecasting).
+# Copyright 2025 Datadog, Inc.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MLX-native t0-alpha model and inference API."""
+
+import dataclasses
+import json
+import logging
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from huggingface_hub import snapshot_download
+
+from t0_mlx.config import T0Config
+from t0_mlx.data import MaskType, TimeSeries, VariateType
+from t0_mlx.layers import PatchEncoder, Patcher, QuantileHead, ResidualBlock, Transformer
+from t0_mlx.quantile import interpolate_quantiles, reduce_rollout_quantiles, validate_quantiles
+from t0_mlx.scaler import CausalScaler
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_HORIZON = 1024
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return -(-value // multiple) * multiple
+
+
+def _sanitize_predictions(predictions: mx.array) -> mx.array:
+    """Cast to float32 and replace NaN/Inf with 0.0 while making the failure visible."""
+    predictions = predictions.astype(mx.float32)
+    non_finite_count = mx.sum(~mx.isfinite(predictions))
+    mx.eval(non_finite_count)
+    count = int(np.asarray(non_finite_count).item())
+    if count > 0:
+        logger.warning("replaced %d non-finite prediction values with 0.0", count)
+        predictions = mx.where(mx.isfinite(predictions), predictions, mx.array(0.0, dtype=mx.float32))
+    return predictions
+
+
+@dataclasses.dataclass
+class Forecast:
+    """Quantile forecast.
+
+    ``quantiles`` is ``(B, horizon, Q)`` or ``(B, V, horizon, Q)``, with
+    the last axis ordered like ``quantile_levels``.
+    """
+
+    quantiles: mx.array
+    quantile_levels: tuple[float, ...]
+
+    @property
+    def median(self) -> mx.array:
+        """The 0.5 quantile, interpolated from ``quantiles`` when needed."""
+        if 0.5 in self.quantile_levels:
+            return self.quantiles[..., self.quantile_levels.index(0.5)]
+        return interpolate_quantiles((0.5,), self.quantile_levels, self.quantiles)[..., 0]
+
+
+class T0Forecaster(nn.Module):
+    """Open-weights t0-alpha forecasting backbone for MLX inference.
+
+    Construct with explicit hyperparameters, or via ``from_config`` /
+    ``from_pretrained``. ``embed_dim`` must be divisible by ``num_heads`` and
+    ``group_every_n`` must divide ``num_layers``.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_layers: int,
+        num_heads: int,
+        mlp_hidden_dim: int,
+        patch_size: int,
+        group_every_n: int,
+        dropout: float,
+        quantile_levels: Sequence[float],
+        scaler_use_arcsinh: bool = True,
+        **_: Any,
+    ):
+        super().__init__()
+        self.config = T0Config(
+            embed_dim=embed_dim,
+            num_layers=num_layers,
+            num_heads=num_heads,
+            mlp_hidden_dim=mlp_hidden_dim,
+            patch_size=patch_size,
+            group_every_n=group_every_n,
+            dropout=dropout,
+            quantile_levels=tuple(quantile_levels),
+            scaler_use_arcsinh=scaler_use_arcsinh,
+        )
+        self.patch_size = patch_size
+        self.max_horizon = DEFAULT_MAX_HORIZON
+        self.patcher = Patcher(patch_size)
+        self.head = QuantileHead(quantile_levels)
+        # The PyTorch T0Forecaster deliberately constructs its scaler with
+        # patch_size=1: the published checkpoint was trained with per-time-step
+        # running statistics. rescale_predictions selects the statistic at each
+        # model patch's right edge.
+        self.scaler = CausalScaler(use_arcsinh=scaler_use_arcsinh)
+        self.patch_encoder = PatchEncoder(embed_dim, patch_size)
+        self.transformer = Transformer(
+            num_layers,
+            embed_dim,
+            num_heads,
+            mlp_hidden_dim,
+            dropout,
+            group_every_n,
+        )
+        self.decoder = ResidualBlock(embed_dim, embed_dim, patch_size * self.head.n_quantiles)
+        self._compiled_single_pass = None
+
+    @classmethod
+    def from_config(cls, config: T0Config) -> "T0Forecaster":
+        """Construct an uninitialized model from architecture configuration."""
+        return cls(**config.to_dict())
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_id_or_path: str | Path,
+        *,
+        revision: str | None = None,
+        token: str | bool | None = None,
+        local_files_only: bool = False,
+    ) -> "T0Forecaster":
+        """Load `config.json` and the original safetensors checkpoint.
+
+        The published PyTorch tensor layouts are already compatible with MLX,
+        so loading is strict and does not transpose or numerically convert any
+        model weight.
+        """
+        candidate = Path(model_id_or_path).expanduser()
+        if candidate.is_dir():
+            model_path = candidate
+        else:
+            model_path = Path(
+                snapshot_download(
+                    repo_id=str(model_id_or_path),
+                    revision=revision,
+                    token=token,
+                    local_files_only=local_files_only,
+                    allow_patterns=["config.json", "model.safetensors"],
+                )
+            )
+        config_path = model_path / "config.json"
+        weights_path = model_path / "model.safetensors"
+        if not config_path.is_file() or not weights_path.is_file():
+            raise FileNotFoundError(f"{model_path} must contain config.json and model.safetensors")
+
+        model = cls.from_config(T0Config.from_json(config_path))
+        model.load_weights(str(weights_path), strict=True)
+        model.eval()
+        mx.eval(model.parameters())
+        return model
+
+    def save_pretrained(self, directory: str | Path) -> None:
+        """Write a strict-loadable `config.json` and `model.safetensors`."""
+        destination = Path(directory)
+        destination.mkdir(parents=True, exist_ok=True)
+        with (destination / "config.json").open("w", encoding="utf-8") as config_file:
+            json.dump(self.config.to_dict(), config_file, indent=2)
+            config_file.write("\n")
+        self.save_weights(str(destination / "model.safetensors"))
+
+    def __call__(self, model_input: TimeSeries) -> mx.array:
+        """Return per-patch values on the model's native quantile grid."""
+        padded = self.patcher.pad(model_input)
+        values = self.patcher.patch(padded.variates)
+        mask = self.patcher.patch(padded.mask)
+        variate_type = self.patcher.patch(padded.variate_type)
+        group_ids = self.patcher.patch(padded.group_ids)
+
+        embeddings = self.patch_encoder(values, mask, variate_type)
+        embeddings = self.transformer(embeddings, group_ids, variate_type, mask)
+        decoded = self.decoder(embeddings)
+        decoded = decoded.reshape(*decoded.shape[:-1], self.patch_size, self.head.n_quantiles)
+        return self.head(decoded)
+
+    def compile(self, *, shapeless: bool = False) -> "T0Forecaster":
+        """Compile the scaling, model, and rescaling graph for repeated inference."""
+        self._compiled_single_pass = mx.compile(
+            self._single_pass_arrays,
+            inputs=self.state,
+            shapeless=shapeless,
+        )
+        return self
+
+    def uncompile(self) -> "T0Forecaster":
+        """Return to eager MLX execution."""
+        self._compiled_single_pass = None
+        return self
+
+    def predict(
+        self,
+        context: mx.array | np.ndarray | list[Any] | tuple[Any, ...],
+        horizon: int,
+        quantiles: Sequence[float] = (0.1, 0.5, 0.9),
+        future_covariates: mx.array | np.ndarray | None = None,
+        mask: mx.array | np.ndarray | None = None,
+        group_ids: mx.array | np.ndarray | None = None,
+    ) -> Forecast:
+        """Forecast ``horizon`` future timesteps for a batch of series.
+
+        Args:
+            context: Past observations — ``[T]`` / ``[B, T]`` (independent
+                univariate series) or ``[B, V, T]`` (multivariate, jointly
+                forecast). NaN marks a missing observation unless ``mask`` says
+                otherwise.
+            horizon: Number of future timesteps to forecast.
+            quantiles: Quantile levels to return, sorted ascending in
+                ``(0, 1)``; levels the model was not trained on are interpolated.
+            future_covariates: Optional ``[B, F, T + horizon]`` covariates known
+                over the context and horizon (for example calendar features);
+                conditioned on but not forecast. NaN over the horizon is 0.
+            mask: ``MaskType`` values shaped like ``context``: ``MISSING`` for an
+                absent observation, ``PAD`` for a cell that only pads a shorter
+                series out to the batch's width.
+                Defaults to reading every NaN in ``context`` as a missing observation.
+                Only all-``PAD`` patches are left unattended.
+            group_ids: One id per row of the context — per row of a ``[B, T]``
+                one, per sample-variate row of a ``[B, V, T]`` one — marking
+                which rows are variates of the same series; rows sharing an id
+                are forecast jointly. Defaults to one series per sample. Cannot
+                be combined with ``future_covariates``.
+
+        Returns:
+            A float32, finite forecast with quantiles shaped
+            ``[B, horizon, Q]`` or ``[B, V, horizon, Q]``.
+
+        Up to ``max_horizon`` timesteps are decoded in one pass; longer
+        horizons continue autoregressively.
+        """
+        if horizon < 1:
+            raise ValueError(f"horizon must be >= 1, got {horizon}")
+        if self.max_horizon < self.patch_size or self.max_horizon % self.patch_size != 0:
+            raise ValueError(
+                f"max_horizon must be a positive multiple of patch_size ({self.patch_size}), got {self.max_horizon}"
+            )
+        requested_quantiles = validate_quantiles(quantiles)
+
+        context_array = mx.array(context, dtype=mx.float32)
+        mask_array = None if mask is None else mx.array(mask)
+        group_array = None if group_ids is None else mx.array(group_ids)
+        future_array = None if future_covariates is None else mx.array(future_covariates, dtype=mx.float32)
+        model_input = TimeSeries.from_context(
+            context_array,
+            mask_array,
+            group_array,
+            future_array,
+            horizon,
+        )
+        target_count = context_array.size // context_array.shape[-1]
+
+        forecast_width = _round_up(horizon, self.patch_size)
+        context_length = context_array.shape[-1]
+        context_width = _round_up(context_length, self.patch_size)
+        buffer = self._prepare_single_pass_buffer(model_input, forecast_width, context_length)
+
+        step_horizon = min(forecast_width, self.max_horizon)
+        window = buffer.time_slice(0, context_width + step_horizon)
+        native = self._predict_step(window, step_horizon)[:target_count]
+        prediction = interpolate_quantiles(requested_quantiles, self.config.quantile_levels, native)
+
+        if horizon > step_horizon:
+            paths = self._expand_prediction_paths(buffer, len(requested_quantiles))
+            predictions = [prediction]
+            decoded = step_horizon
+            remaining = horizon - step_horizon
+            while remaining > 0:
+                previous_width = predictions[-1].shape[1]
+                paths = self._update_buffer_with_predictions(
+                    paths,
+                    predictions[-1],
+                    at=context_width + decoded - previous_width,
+                )
+                step_horizon = min(_round_up(remaining, self.patch_size), self.max_horizon)
+                window = paths.time_slice(decoded, context_width + decoded + step_horizon)
+                native = self._predict_step(window, step_horizon)[: target_count * len(requested_quantiles)]
+                native = native.reshape(
+                    target_count,
+                    len(requested_quantiles),
+                    step_horizon,
+                    self.head.n_quantiles,
+                ).transpose(0, 1, 3, 2)
+                prediction = reduce_rollout_quantiles(
+                    native,
+                    self.config.quantile_levels,
+                    requested_quantiles,
+                )
+                predictions.append(prediction)
+                decoded += step_horizon
+                remaining -= step_horizon
+            prediction = mx.concatenate(predictions, axis=1)
+
+        predictions = _sanitize_predictions(prediction[:, :horizon])
+        if context_array.ndim == 3:
+            predictions = predictions.reshape(
+                context_array.shape[0],
+                context_array.shape[1],
+                horizon,
+                len(requested_quantiles),
+            )
+        mx.eval(predictions)
+        return Forecast(predictions, requested_quantiles)
+
+    def _predict_step(self, window: TimeSeries, horizon: int) -> mx.array:
+        if self._compiled_single_pass is None:
+            predictions = self._single_pass_arrays(
+                window.variates,
+                window.mask,
+                window.group_ids,
+                window.variate_type,
+            )
+        else:
+            predictions = self._compiled_single_pass(
+                window.variates,
+                window.mask,
+                window.group_ids,
+                window.variate_type,
+            )
+        context_patches = (window.seq_len - horizon) // self.patch_size
+        horizon_patches = horizon // self.patch_size
+        predictions = predictions[:, context_patches - 1 : context_patches - 1 + horizon_patches]
+        return predictions.reshape(predictions.shape[0], horizon, self.head.n_quantiles)
+
+    def _expand_prediction_paths(self, buffer: TimeSeries, n_paths: int) -> TimeSeries:
+        rows, width = buffer.variates.shape
+        expanded_values = mx.repeat(buffer.variates[:, None, :], n_paths, axis=1).reshape(rows * n_paths, width)
+        expanded_mask = mx.repeat(buffer.mask[:, None, :], n_paths, axis=1).reshape(rows * n_paths, width)
+        row_groups = buffer.group_ids[:, -1]
+        path_groups = (row_groups[:, None] * n_paths + mx.arange(n_paths)[None, :]).reshape(-1)
+        expanded_groups = mx.broadcast_to(path_groups[:, None], (rows * n_paths, width))
+        row_types = buffer.variate_type[:, -1]
+        path_types = mx.repeat(row_types, n_paths)
+        expanded_types = mx.broadcast_to(path_types[:, None], (rows * n_paths, width))
+        return TimeSeries(expanded_values, expanded_mask, expanded_groups, expanded_types)
+
+    def _update_buffer_with_predictions(self, buffer: TimeSeries, prediction: mx.array, at: int) -> TimeSeries:
+        targets, horizon, n_paths = prediction.shape
+        target_path_rows = targets * n_paths
+        flattened = prediction.transpose(0, 2, 1).reshape(target_path_rows, horizon)
+        target_values = mx.concatenate(
+            [buffer.variates[:target_path_rows, :at], flattened, buffer.variates[:target_path_rows, at + horizon :]],
+            axis=1,
+        )
+        target_mask = mx.concatenate(
+            [
+                buffer.mask[:target_path_rows, :at],
+                mx.full((target_path_rows, horizon), MaskType.VALID, dtype=mx.int8),
+                buffer.mask[:target_path_rows, at + horizon :],
+            ],
+            axis=1,
+        )
+        return TimeSeries(
+            variates=mx.concatenate([target_values, buffer.variates[target_path_rows:]], axis=0),
+            mask=mx.concatenate([target_mask, buffer.mask[target_path_rows:]], axis=0),
+            group_ids=buffer.group_ids,
+            variate_type=buffer.variate_type,
+        )
+
+    def _single_pass_arrays(
+        self,
+        variates: mx.array,
+        mask: mx.array,
+        group_ids: mx.array,
+        variate_type: mx.array,
+    ) -> mx.array:
+        buffer = TimeSeries(variates, mask, group_ids, variate_type)
+        scaled, loc_scale = self.scaler.scale_input(buffer)
+        return self.scaler.rescale_predictions(self(scaled), loc_scale, self.patch_size)
+
+    def _prepare_single_pass_buffer(
+        self,
+        context: TimeSeries,
+        prediction_width: int,
+        context_length: int,
+    ) -> TimeSeries:
+        rows = context.variates.shape[0]
+        left_pad = (-context_length) % self.patch_size
+        row_groups = context.group_ids[:, :1]
+        row_types = context.variate_type[:, :1]
+        target_rows = row_types[:, 0] == VariateType.TARGET
+        future_rows = row_types[:, 0] == VariateType.FUTURE
+        known = min(context.seq_len - context_length, prediction_width)
+
+        forecast_values = mx.zeros((rows, prediction_width), dtype=mx.float32)
+        forecast_mask = mx.full((rows, prediction_width), MaskType.PAD, dtype=mx.int8)
+        forecast_mask = mx.where(target_rows[:, None], MaskType.WITHHELD, forecast_mask).astype(mx.int8)
+        if known > 0:
+            known_columns = mx.arange(prediction_width)[None, :] < known
+            copy_future = future_rows[:, None] & known_columns
+            source_values = context.variates[:, context_length : context_length + known]
+            source_mask = context.mask[:, context_length : context_length + known]
+            padded_values = mx.concatenate(
+                [source_values, mx.zeros((rows, prediction_width - known), dtype=mx.float32)],
+                axis=1,
+            )
+            padded_mask = mx.concatenate(
+                [source_mask, mx.full((rows, prediction_width - known), MaskType.PAD, dtype=mx.int8)],
+                axis=1,
+            )
+            forecast_values = mx.where(copy_future, padded_values, forecast_values)
+            forecast_mask = mx.where(copy_future, padded_mask, forecast_mask)
+        return TimeSeries(
+            variates=mx.concatenate(
+                [
+                    mx.zeros((rows, left_pad), dtype=mx.float32),
+                    context.variates[:, :context_length],
+                    forecast_values,
+                ],
+                axis=1,
+            ),
+            mask=mx.concatenate(
+                [
+                    mx.full((rows, left_pad), MaskType.PAD, dtype=mx.int8),
+                    context.mask[:, :context_length],
+                    forecast_mask,
+                ],
+                axis=1,
+            ),
+            group_ids=mx.concatenate(
+                [
+                    mx.full((rows, left_pad), -1, dtype=mx.int32),
+                    context.group_ids[:, :context_length],
+                    mx.broadcast_to(row_groups, (rows, prediction_width)),
+                ],
+                axis=1,
+            ),
+            variate_type=mx.concatenate(
+                [
+                    mx.full((rows, left_pad), -1, dtype=mx.int32),
+                    context.variate_type[:, :context_length],
+                    mx.broadcast_to(row_types, (rows, prediction_width)),
+                ],
+                axis=1,
+            ),
+        )

--- a/mlx/t0_mlx/quantile.py
+++ b/mlx/t0_mlx/quantile.py
@@ -1,0 +1,101 @@
+# Copyright 2026 The Forecasting Company
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# The weighted-quantile and probability-mass computations are adapted from
+# Chronos-2 (https://github.com/amazon-science/chronos-forecasting,
+# src/chronos/utils.py and src/chronos/chronos2/pipeline.py).
+# SPDX-License-Identifier: Apache-2.0
+
+"""Quantile interpolation and autoregressive rollout reduction."""
+
+from bisect import bisect_right
+from collections.abc import Sequence
+
+import mlx.core as mx
+
+
+def validate_quantiles(quantiles: Sequence[float]) -> tuple[float, ...]:
+    """Validate and normalize a public quantile request."""
+    levels = tuple(float(level) for level in quantiles)
+    if not levels:
+        raise ValueError("quantiles must be non-empty")
+    if any(not 0.0 < level < 1.0 for level in levels):
+        raise ValueError("each quantile must be in (0, 1)")
+    if levels != tuple(sorted(set(levels))):
+        raise ValueError("quantiles must be sorted ascending without duplicates")
+    return levels
+
+
+def interpolate_quantiles(query_levels: Sequence[float], source_levels: Sequence[float], values: mx.array) -> mx.array:
+    """Linearly interpolate values and hold the endpoint quantiles constant."""
+    source = tuple(float(level) for level in source_levels)
+    columns: list[mx.array] = []
+    for query in query_levels:
+        upper = bisect_right(source, query)
+        if upper == 0:
+            columns.append(values[..., 0])
+        elif upper == len(source):
+            columns.append(values[..., -1])
+        else:
+            lower = upper - 1
+            weight = (query - source[lower]) / (source[upper] - source[lower])
+            columns.append(values[..., lower] + weight * (values[..., upper] - values[..., lower]))
+    return mx.stack(columns, axis=-1)
+
+
+def get_probability_mass(quantile_levels: Sequence[float]) -> mx.array:
+    """Return normalized trapezoidal probability mass for quantile levels."""
+    levels = mx.array(list(quantile_levels), dtype=mx.float32)
+    boundaries = mx.concatenate([mx.array([0.0]), levels, mx.array([1.0])])
+    mass = (boundaries[2:] - boundaries[:-2]) / 2.0
+    return mass / mx.sum(mass)
+
+
+def _interpolate_dynamic(query_levels: Sequence[float], levels: mx.array, values: mx.array) -> mx.array:
+    """Interpolate when each flattened row has its own sorted level grid."""
+    query = mx.array(list(query_levels), dtype=mx.float32)
+    levels = mx.concatenate([mx.zeros_like(levels[:, :1]), levels, mx.ones_like(levels[:, :1])], axis=1)
+    values = mx.concatenate([values[:, :1], values, values[:, -1:]], axis=1)
+
+    upper = mx.sum(levels[:, :, None] <= query[None, None, :], axis=1).astype(mx.int32)
+    upper = mx.minimum(upper, levels.shape[1] - 1)
+    lower = upper - 1
+    lower_levels = mx.take_along_axis(levels, lower, axis=1)
+    upper_levels = mx.take_along_axis(levels, upper, axis=1)
+    lower_values = mx.take_along_axis(values, lower, axis=1)
+    upper_values = mx.take_along_axis(values, upper, axis=1)
+    weight = mx.nan_to_num((query[None, :] - lower_levels) / (upper_levels - lower_levels), nan=0.0)
+    return lower_values + weight * (upper_values - lower_values)
+
+
+def weighted_quantile(query_levels: Sequence[float], sample_weights: mx.array, samples: mx.array) -> mx.array:
+    """Reduce weighted samples through their empirical cumulative distribution."""
+    original_shape = samples.shape
+    n_samples = original_shape[-1]
+    flattened = samples.reshape(-1, n_samples).astype(mx.float32)
+    order = mx.argsort(flattened, axis=-1)
+    sorted_samples = mx.take_along_axis(flattened, order, axis=-1)
+
+    normalized_weights = sample_weights / mx.sum(sample_weights)
+    weights = mx.broadcast_to(normalized_weights[None, :], flattened.shape)
+    sorted_weights = mx.take_along_axis(weights, order, axis=-1)
+    cumulative = mx.clip(mx.cumsum(sorted_weights, axis=-1), 0.0, 1.0)
+    result = _interpolate_dynamic(query_levels, cumulative, sorted_samples)
+    return result.reshape(*original_shape[:-1], len(query_levels)).astype(samples.dtype)
+
+
+def reduce_rollout_quantiles(
+    predictions: mx.array,
+    predicted_levels: Sequence[float],
+    query_levels: Sequence[float],
+) -> mx.array:
+    """Reduce `[targets, query_paths, native_quantiles, horizon]` to requested quantiles."""
+    native_mass = get_probability_mass(predicted_levels)
+    query_mass = get_probability_mass(query_levels)
+    sample_weights = (native_mass[:, None] * query_mass[None, :]).reshape(-1)
+    samples = predictions.transpose(0, 3, 2, 1).reshape(
+        predictions.shape[0],
+        predictions.shape[3],
+        -1,
+    )
+    return weighted_quantile(query_levels, sample_weights, samples)

--- a/mlx/t0_mlx/scaler.py
+++ b/mlx/t0_mlx/scaler.py
@@ -1,0 +1,100 @@
+# Copyright 2026 The Forecasting Company
+# The Welford-style cumulative causal statistics borrow from Datadog's Toto
+# scaler (https://github.com/DataDog/toto).
+# Copyright 2025 Datadog, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Causal scaling for the single-pass inference path."""
+
+from dataclasses import dataclass
+
+import mlx.core as mx
+
+from t0_mlx.data import TimeSeries, VariateType
+
+EPS = 1e-1
+
+
+@dataclass
+class LocScale:
+    """Per-row, per-time-step location and scale."""
+
+    loc: mx.array
+    scale: mx.array
+
+
+def _compute_causal_stats(x: mx.array, invalid: mx.array) -> tuple[mx.array, mx.array]:
+    """Match the reference cumulative Welford calculation for one series per row."""
+    valid = ~invalid
+    counts = mx.cumsum(valid.astype(x.dtype), axis=-1)
+    safe_counts = mx.maximum(counts, mx.array(1.0, dtype=x.dtype))
+    masked_x = mx.where(invalid, mx.array(0.0, dtype=x.dtype), x)
+    means = mx.cumsum(masked_x, axis=-1) / safe_counts
+
+    shifted_means = mx.concatenate([mx.zeros_like(means[:, :1]), means[:, :-1]], axis=-1)
+    delta = masked_x - shifted_means
+    increments = delta * (masked_x - means) * valid.astype(x.dtype)
+    m2 = mx.maximum(mx.cumsum(increments, axis=-1), mx.array(0.0, dtype=x.dtype))
+    variance = m2 / mx.maximum(safe_counts - 1.0, mx.array(1.0, dtype=x.dtype))
+    return means, mx.sqrt(variance + EPS)
+
+
+def _compute_global_stats(x: mx.array, invalid: mx.array) -> tuple[mx.array, mx.array]:
+    """Compute global population statistics independently for each row."""
+    valid = ~invalid
+    counts = mx.sum(valid.astype(x.dtype), axis=-1, keepdims=True)
+    safe_counts = mx.maximum(counts, mx.array(1.0, dtype=x.dtype))
+    masked = mx.where(invalid, mx.array(0.0, dtype=x.dtype), x)
+    means = mx.sum(masked, axis=-1, keepdims=True) / safe_counts
+    squared = mx.where(invalid, mx.array(0.0, dtype=x.dtype), mx.square(x - means))
+    variance = mx.sum(squared, axis=-1, keepdims=True) / mx.maximum(
+        counts,
+        mx.array(2.0, dtype=x.dtype),
+    )
+    scales = mx.maximum(mx.sqrt(variance), mx.array(EPS, dtype=x.dtype))
+    return mx.broadcast_to(means, x.shape), mx.broadcast_to(scales, x.shape)
+
+
+class CausalScaler:
+    """Per-row causal normalization used by the published checkpoint.
+
+    The reference ``T0Forecaster`` uses scaler patch size 1, so targets and
+    historicals retain one running statistic per timestep. Forecasts are
+    inverse-scaled with the statistic at each model patch's right edge.
+    """
+
+    def __init__(self, use_arcsinh: bool = True):
+        self.use_arcsinh = use_arcsinh
+
+    def scale_input(self, model_input: TimeSeries) -> tuple[TimeSeries, LocScale]:
+        invalid = ~model_input.valid_mask
+        causal_loc, causal_scale = _compute_causal_stats(model_input.variates, invalid)
+        future_loc, future_scale = _compute_global_stats(model_input.variates, invalid)
+        non_padding = model_input.group_ids >= 0
+        is_future = non_padding & (model_input.variate_type == VariateType.FUTURE)
+        is_causal = non_padding & ~is_future
+        loc = mx.where(is_causal, causal_loc, mx.zeros_like(causal_loc))
+        scale = mx.where(is_causal, causal_scale, mx.ones_like(causal_scale))
+        loc = mx.where(is_future, future_loc, loc)
+        scale = mx.where(is_future, future_scale, scale)
+        normalized = (model_input.variates - loc) / scale
+        if self.use_arcsinh:
+            normalized = mx.arcsinh(normalized)
+        return (
+            TimeSeries(
+                variates=normalized,
+                mask=model_input.mask,
+                group_ids=model_input.group_ids,
+                variate_type=model_input.variate_type,
+            ),
+            LocScale(loc=loc, scale=scale),
+        )
+
+    def rescale_predictions(self, predictions: mx.array, loc_scale: LocScale, model_patch_size: int) -> mx.array:
+        loc = loc_scale.loc[:, model_patch_size - 1 :: model_patch_size]
+        scale = loc_scale.scale[:, model_patch_size - 1 :: model_patch_size]
+        for _ in range(predictions.ndim - 2):
+            loc = mx.expand_dims(loc, axis=-1)
+            scale = mx.expand_dims(scale, axis=-1)
+        values = mx.sinh(predictions) if self.use_arcsinh else predictions
+        return values * scale + loc

--- a/mlx/tests/test_benchmark.py
+++ b/mlx/tests/test_benchmark.py
@@ -1,0 +1,47 @@
+"""The backend benchmark must compare complete forecasts, not only checksums."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+TOOLS = Path(__file__).parent.parent / "tools"
+sys.path.insert(0, str(TOOLS))
+
+from benchmark import _compare_with_torch_cpu, _remove_raw_outputs  # noqa: E402
+
+
+def _result(backend: str, output: list[float]) -> dict:
+    return {
+        "backend": backend,
+        "timings": [
+            {
+                "workload": {"batch": 1, "context": 4, "horizon": 2},
+                "output_shape": [1, 2, 2],
+                "output": output,
+            }
+        ],
+    }
+
+
+def test_elementwise_comparison_detects_compensating_checksum_error() -> None:
+    # Both outputs sum to ten; a checksum-only guard would miss the corruption.
+    results = [
+        _result("torch-mps", [1.0, 1.0, 4.0, 4.0]),
+        _result("torch-cpu", [1.0, 2.0, 3.0, 4.0]),
+    ]
+    [comparison] = _compare_with_torch_cpu(results, rtol=0.0, atol=1e-4)
+    assert comparison.max_abs_error == 1.0
+    assert not comparison.within_tolerance
+
+
+def test_elementwise_comparison_accepts_small_backend_drift() -> None:
+    results = [
+        _result("torch-mps", [1.0, 2.00001, 3.0, 4.0]),
+        _result("torch-cpu", [1.0, 2.0, 3.0, 4.0]),
+    ]
+    [comparison] = _compare_with_torch_cpu(results, rtol=0.0, atol=2e-5)
+    assert comparison.within_tolerance
+
+    _remove_raw_outputs(results)
+    assert all("output" not in timing for result in results for timing in result["timings"])

--- a/mlx/tests/test_checkpoint_parity.py
+++ b/mlx/tests/test_checkpoint_parity.py
@@ -1,0 +1,268 @@
+"""Parity gates against the original PyTorch model and checkpoint."""
+
+import os
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from t0_mlx import T0Config
+from t0_mlx import batch_series as mlx_batch_series
+from t0_mlx.data import TimeSeries as MLXTimeSeries
+from t0_mlx.layers import PatchEncoder
+from t0_mlx.quantile import reduce_rollout_quantiles
+from t0_mlx.scaler import CausalScaler as MLXCausalScaler
+
+CHECKPOINT_ENV = "T0_MLX_CHECKPOINT"
+
+
+def _checkpoint() -> Path:
+    value = os.environ.get(CHECKPOINT_ENV)
+    if value is None:
+        pytest.skip(f"set {CHECKPOINT_ENV} to run checkpoint-backed parity")
+    path = Path(value)
+    if not (path / "config.json").is_file() or not (path / "model.safetensors").is_file():
+        pytest.fail(f"{path} must contain config.json and model.safetensors")
+    return path
+
+
+def test_patch_encoder_matches_pytorch_checkpoint() -> None:
+    torch = pytest.importorskip("torch")
+    t0 = pytest.importorskip("t0")
+    checkpoint = _checkpoint()
+    config = T0Config.from_json(checkpoint / "config.json")
+
+    reference = t0.T0Forecaster.from_pretrained(checkpoint).eval()
+    candidate = PatchEncoder(config.embed_dim, config.patch_size)
+    weights = mx.load(str(checkpoint / "model.safetensors"))
+    prefix = "patch_encoder."
+    candidate.load_weights(
+        [(key.removeprefix(prefix), value) for key, value in weights.items() if key.startswith(prefix)]
+    )
+    candidate.eval()
+
+    rng = np.random.default_rng(17)
+    values = rng.normal(size=(3, 4, config.patch_size)).astype(np.float32)
+    mask = np.zeros(values.shape, dtype=np.int8)
+    mask[1, 0, :7] = 1
+    mask[2, 2, 9:15] = 2
+    values[mask != 0] = 0.0
+    variate_type = np.zeros(values.shape, dtype=np.int64)
+    variate_type[2] = 2
+
+    with torch.inference_mode():
+        expected = reference.patch_encoder(
+            torch.from_numpy(values),
+            torch.from_numpy(mask),
+            torch.from_numpy(variate_type),
+        ).numpy()
+    actual = candidate(mx.array(values), mx.array(mask), mx.array(variate_type))
+    mx.eval(actual)
+
+    np.testing.assert_allclose(np.asarray(actual), expected, rtol=1e-5, atol=2e-5)
+
+
+def test_scaler_and_rollout_quantiles_match_pytorch() -> None:
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("t0")
+    from t0.data import TimeSeries as TorchTimeSeries
+    from t0.quantile import QuantileRolloutReducer
+    from t0.scaler import CausalScaler as TorchCausalScaler
+
+    values = np.array(
+        [[1.0, 2.0, np.nan, 8.0, 13.0], [3.0, -2.0, 4.0, 7.0, 11.0]],
+        dtype=np.float32,
+    )
+    torch_input = TorchTimeSeries.from_array(torch.from_numpy(values))
+    mlx_input = MLXTimeSeries.from_context(mx.array(values))
+    with torch.inference_mode():
+        expected_scaled, expected_stats = TorchCausalScaler(patch_size=1, use_arcsinh=True).scale_input(torch_input)
+    actual_scaled, actual_stats = MLXCausalScaler(use_arcsinh=True).scale_input(mlx_input)
+    mx.eval(actual_scaled.variates, actual_stats.loc, actual_stats.scale)
+
+    np.testing.assert_allclose(np.asarray(actual_scaled.variates), expected_scaled.variates.numpy(), atol=2e-6)
+    np.testing.assert_allclose(np.asarray(actual_stats.loc), expected_stats.loc.numpy(), atol=2e-6)
+    np.testing.assert_allclose(np.asarray(actual_stats.scale), expected_stats.scale.numpy(), atol=2e-6)
+
+    rng = np.random.default_rng(31)
+    predictions = rng.normal(size=(2, 3, 5, 7)).astype(np.float32)
+    predicted_levels = [0.1, 0.25, 0.5, 0.75, 0.9]
+    query_levels = [0.1, 0.5, 0.9]
+    with torch.inference_mode():
+        expected_quantiles = QuantileRolloutReducer(
+            predicted_quantile_levels=torch.tensor(predicted_levels),
+            query_quantile_levels=torch.tensor(query_levels),
+        ).reduce(torch.from_numpy(predictions))
+    actual_quantiles = reduce_rollout_quantiles(mx.array(predictions), predicted_levels, query_levels)
+    mx.eval(actual_quantiles)
+    np.testing.assert_allclose(np.asarray(actual_quantiles), expected_quantiles.numpy(), rtol=1e-6, atol=2e-6)
+
+
+def test_attention_and_rotary_layers_match_pytorch_checkpoint() -> None:
+    torch = pytest.importorskip("torch")
+    t0 = pytest.importorskip("t0")
+    from t0_mlx import T0Forecaster as MLXT0Forecaster
+
+    checkpoint = _checkpoint()
+    reference = t0.T0Forecaster.from_pretrained(checkpoint).eval()
+    candidate = MLXT0Forecaster.from_pretrained(checkpoint).eval()
+    rng = np.random.default_rng(29)
+
+    head_dim = candidate.config.embed_dim // candidate.config.num_heads
+    queries = rng.normal(size=(2, candidate.config.num_heads, 5, head_dim)).astype(np.float32)
+    keys = rng.normal(size=queries.shape).astype(np.float32)
+    with torch.inference_mode():
+        expected_queries, expected_keys = reference.transformer.rotary_emb.rotate_queries_and_keys(
+            torch.from_numpy(queries),
+            torch.from_numpy(keys),
+            seq_dim=-2,
+        )
+    rotary = candidate.transformer.layers[0].attention_block.attention.rotary
+    assert rotary is not None
+    actual_queries, actual_keys = rotary.rotate_queries_and_keys(mx.array(queries), mx.array(keys))
+    mx.eval(actual_queries, actual_keys)
+    np.testing.assert_allclose(np.asarray(actual_queries), expected_queries.numpy(), rtol=1e-5, atol=2e-5)
+    np.testing.assert_allclose(np.asarray(actual_keys), expected_keys.numpy(), rtol=1e-5, atol=2e-5)
+
+    hidden = rng.normal(size=(3, 5, candidate.config.embed_dim)).astype(np.float32)
+    time_mask = np.broadcast_to(np.tril(np.ones((5, 5), dtype=bool)), (3, 1, 5, 5)).copy()
+    with torch.inference_mode():
+        expected_time = reference.transformer.layers[0].attention_block(
+            torch.from_numpy(hidden), torch.from_numpy(time_mask)
+        )
+    actual_time = candidate.transformer.layers[0].attention_block(mx.array(hidden), mx.array(time_mask))
+    mx.eval(actual_time)
+    np.testing.assert_allclose(np.asarray(actual_time), expected_time.numpy(), rtol=2e-5, atol=2e-4)
+
+    group_index = candidate.config.group_every_n - 1
+    group_mask = np.ones((5, 1, 3, 3), dtype=bool)
+    with torch.inference_mode():
+        expected_group = reference.transformer.layers[group_index].attention_block(
+            torch.from_numpy(hidden), torch.from_numpy(group_mask)
+        )
+    actual_group = candidate.transformer.layers[group_index].attention_block(mx.array(hidden), mx.array(group_mask))
+    mx.eval(actual_group)
+    np.testing.assert_allclose(np.asarray(actual_group), expected_group.numpy(), rtol=2e-5, atol=2e-4)
+
+
+def test_single_pass_forecast_matches_pytorch_checkpoint() -> None:
+    torch = pytest.importorskip("torch")
+    t0 = pytest.importorskip("t0")
+    from t0_mlx import T0Forecaster as MLXT0Forecaster
+
+    checkpoint = _checkpoint()
+    reference = t0.T0Forecaster.from_pretrained(checkpoint).eval()
+    assert reference.scaler.patch_size == 1
+    candidate = MLXT0Forecaster.from_pretrained(checkpoint)
+
+    time = np.arange(97, dtype=np.float32)
+    context = np.stack(
+        [
+            0.25 * time + 3.0,
+            np.sin(time / 7.0) + 0.2 * np.cos(time / 3.0),
+            np.sqrt(time + 1.0),
+        ]
+    ).astype(np.float32)
+    context[2, [3, 4, 31, 80]] = np.nan
+    quantiles = [0.1, 0.2, 0.5, 0.8, 0.9]
+
+    with torch.inference_mode():
+        expected = reference.predict(context, horizon=64, quantiles=quantiles).quantiles.numpy()
+    actual = np.asarray(candidate.predict(context, horizon=64, quantiles=quantiles).quantiles)
+    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=2e-4)
+
+    compiled = np.asarray(candidate.compile().predict(context, horizon=64, quantiles=quantiles).quantiles)
+    np.testing.assert_allclose(compiled, expected, rtol=1e-5, atol=2e-4)
+
+    candidate.uncompile()
+    multivariate = context[:2].reshape(1, 2, -1)
+    with torch.inference_mode():
+        expected_multivariate = reference.predict(multivariate, horizon=32, quantiles=[0.1, 0.5, 0.9]).quantiles.numpy()
+    actual_multivariate = np.asarray(candidate.predict(multivariate, horizon=32, quantiles=[0.1, 0.5, 0.9]).quantiles)
+    np.testing.assert_allclose(actual_multivariate, expected_multivariate, rtol=1e-5, atol=2e-4)
+
+    grouped = context
+    group_ids = np.array([0, 0, 1])
+    with torch.inference_mode():
+        expected_grouped = reference.predict(
+            grouped,
+            horizon=32,
+            quantiles=[0.1, 0.5, 0.9],
+            group_ids=group_ids,
+        ).quantiles.numpy()
+    actual_grouped = np.asarray(
+        candidate.predict(grouped, horizon=32, quantiles=[0.1, 0.5, 0.9], group_ids=group_ids).quantiles
+    )
+    np.testing.assert_allclose(actual_grouped, expected_grouped, rtol=1e-5, atol=2e-4)
+
+    ragged_series = [context[0, :17], np.stack([context[1, :65], context[2, :65]])]
+    torch_context, torch_mask, torch_groups = t0.batch_series(ragged_series)
+    mlx_context, mlx_mask, mlx_groups = mlx_batch_series(ragged_series)
+    with torch.inference_mode():
+        expected_ragged = reference.predict(
+            torch_context,
+            horizon=32,
+            quantiles=[0.1, 0.5, 0.9],
+            mask=torch_mask,
+            group_ids=torch_groups,
+        ).quantiles.numpy()
+    actual_ragged = np.asarray(
+        candidate.predict(
+            mlx_context,
+            horizon=32,
+            quantiles=[0.1, 0.5, 0.9],
+            mask=mlx_mask,
+            group_ids=mlx_groups,
+        ).quantiles
+    )
+    np.testing.assert_allclose(actual_ragged, expected_ragged, rtol=2e-5, atol=3e-4)
+    actual_short_alone = np.asarray(
+        candidate.predict(ragged_series[0], horizon=32, quantiles=[0.1, 0.5, 0.9]).quantiles
+    )[0]
+    np.testing.assert_allclose(actual_ragged[0], actual_short_alone, rtol=2e-5, atol=3e-4)
+
+    rng = np.random.default_rng(23)
+    future = rng.normal(size=(3, 2, context.shape[-1] + 32)).astype(np.float32)
+    future[1, 0, [4, 103]] = np.nan
+    with torch.inference_mode():
+        expected_future = reference.predict(
+            context,
+            horizon=32,
+            quantiles=[0.1, 0.5, 0.9],
+            future_covariates=future,
+        ).quantiles.numpy()
+    actual_future = np.asarray(
+        candidate.predict(context, horizon=32, quantiles=[0.1, 0.5, 0.9], future_covariates=future).quantiles
+    )
+    np.testing.assert_allclose(actual_future, expected_future, rtol=1e-5, atol=2e-4)
+
+    reference.max_horizon = 64
+    candidate.max_horizon = 64
+    rollout_context = context[:1, :64]
+    with torch.inference_mode():
+        expected_rollout = reference.predict(
+            rollout_context,
+            horizon=96,
+            quantiles=[0.1, 0.5, 0.9],
+        ).quantiles.numpy()
+    actual_rollout = np.asarray(candidate.predict(rollout_context, horizon=96, quantiles=[0.1, 0.5, 0.9]).quantiles)
+    np.testing.assert_allclose(actual_rollout, expected_rollout, rtol=2e-5, atol=3e-4)
+
+    rollout_future = rng.normal(size=(1, 1, rollout_context.shape[-1] + 96)).astype(np.float32)
+    with torch.inference_mode():
+        expected_future_rollout = reference.predict(
+            rollout_context,
+            horizon=96,
+            quantiles=[0.1, 0.5, 0.9],
+            future_covariates=rollout_future,
+        ).quantiles.numpy()
+    actual_future_rollout = np.asarray(
+        candidate.predict(
+            rollout_context,
+            horizon=96,
+            quantiles=[0.1, 0.5, 0.9],
+            future_covariates=rollout_future,
+        ).quantiles
+    )
+    np.testing.assert_allclose(actual_future_rollout, expected_future_rollout, rtol=2e-5, atol=3e-4)

--- a/mlx/tests/test_config.py
+++ b/mlx/tests/test_config.py
@@ -1,0 +1,34 @@
+import json
+
+import pytest
+
+from t0_mlx import T0Config
+
+
+def test_medium_matches_published_checkpoint() -> None:
+    config = T0Config.medium()
+    assert config.embed_dim == 512
+    assert config.num_layers == 24
+    assert config.group_every_n == 3
+    assert config.quantile_levels == (0.1, 0.25, 0.5, 0.75, 0.9)
+
+
+def test_json_round_trip(tmp_path) -> None:
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(T0Config.medium().to_dict()))
+    assert T0Config.from_json(path) == T0Config.medium()
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"embed_dim": 513}, "divisible"),
+        ({"group_every_n": 5}, "divide"),
+        ({"quantile_levels": (0.5, 0.1)}, "sorted"),
+    ],
+)
+def test_invalid_config_is_rejected(override, message) -> None:
+    values = T0Config.medium().to_dict()
+    values.update(override)
+    with pytest.raises(ValueError, match=message):
+        T0Config.from_dict(values)

--- a/mlx/tests/test_layers.py
+++ b/mlx/tests/test_layers.py
@@ -1,0 +1,35 @@
+import mlx.core as mx
+import numpy as np
+
+from t0_mlx.layers import PatchEncoder, QuantileHead, RMSNorm, SwiGLU
+
+
+def test_patch_encoder_shape_and_finiteness() -> None:
+    encoder = PatchEncoder(embed_dim=16, patch_size=4)
+    values = mx.arange(24, dtype=mx.float32).reshape(2, 3, 4)
+    mask = mx.zeros((2, 3, 4), dtype=mx.int8)
+    variate_type = mx.zeros((2, 3, 4), dtype=mx.int32)
+    output = encoder(values, mask, variate_type)
+    mx.eval(output)
+    assert output.shape == (2, 3, 16)
+    assert np.isfinite(np.asarray(output)).all()
+
+
+def test_rms_norm_uses_checkpoint_epsilon() -> None:
+    norm = RMSNorm(3)
+    output = norm(mx.array([[1.0, 2.0, 3.0]], dtype=mx.float32))
+    expected = np.array([[1.0, 2.0, 3.0]]) / np.sqrt(np.mean(np.square([[1.0, 2.0, 3.0]])) + 1e-8)
+    np.testing.assert_allclose(np.asarray(output), expected, rtol=1e-6, atol=1e-6)
+
+
+def test_swiglu_uses_gate_first_order() -> None:
+    output = SwiGLU()(mx.array([[1.0, 2.0, 3.0, 4.0]], dtype=mx.float32))
+    expected = np.array([[1.0 / (1.0 + np.exp(-1.0)) * 3.0, 2.0 / (1.0 + np.exp(-2.0)) * 4.0]])
+    np.testing.assert_allclose(np.asarray(output), expected, rtol=1e-6, atol=1e-6)
+
+
+def test_quantile_head_is_monotone() -> None:
+    output = QuantileHead([0.1, 0.5, 0.9])(mx.array([[[-2.0, -1.0, 0.5]]], dtype=mx.float32))
+    values = np.asarray(output)
+    assert values.shape == (1, 1, 3)
+    assert np.all(values[..., 1:] >= values[..., :-1])

--- a/mlx/tests/test_model.py
+++ b/mlx/tests/test_model.py
@@ -1,0 +1,185 @@
+import logging
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+import pytest
+
+from t0_mlx import Forecast, MaskType, T0Config, T0Forecaster, batch_series
+from t0_mlx import __all__ as t0_all
+from t0_mlx.data import TimeSeries, VariateType
+from t0_mlx.model import _sanitize_predictions
+from t0_mlx.scaler import CausalScaler
+
+
+@pytest.fixture
+def tiny_model() -> T0Forecaster:
+    config = T0Config(
+        embed_dim=16,
+        num_layers=3,
+        num_heads=4,
+        mlp_hidden_dim=32,
+        patch_size=4,
+        group_every_n=3,
+        dropout=0.0,
+        quantile_levels=(0.1, 0.5, 0.9),
+    )
+    model = T0Forecaster.from_config(config)
+    model.eval()
+    return model
+
+
+def test_top_level_api_matches_tfc_t0() -> None:
+    assert t0_all == ["Forecast", "MaskType", "T0Config", "T0Forecaster", "batch_series"]
+
+
+def test_scaler_uses_checkpoint_trained_per_timestep_statistics() -> None:
+    values = mx.array([[1.0, 3.0, 5.0, 7.0]], dtype=mx.float32)
+    model_input = TimeSeries(
+        variates=values,
+        mask=mx.full(values.shape, MaskType.VALID, dtype=mx.int8),
+        group_ids=mx.zeros(values.shape, dtype=mx.int32),
+        variate_type=mx.full(values.shape, VariateType.TARGET, dtype=mx.int32),
+    )
+
+    scaled, loc_scale = CausalScaler(use_arcsinh=False).scale_input(model_input)
+
+    # PyTorch T0Forecaster uses CausalScaler(patch_size=1), so the running
+    # location is retained at every timestep rather than frozen per model patch.
+    np.testing.assert_allclose(np.asarray(loc_scale.loc), [[1.0, 2.0, 3.0, 4.0]])
+    assert loc_scale.loc.shape == values.shape
+    assert scaled.variates.shape == values.shape
+
+    # Inverse scaling selects the statistic at the model patch's right edge.
+    prediction = mx.zeros((1, 1, 4, 1), dtype=mx.float32)
+    restored = CausalScaler(use_arcsinh=False).rescale_predictions(prediction, loc_scale, model_patch_size=4)
+    np.testing.assert_allclose(np.asarray(restored), 4.0)
+
+
+def test_predict_matches_public_shape_contract(tiny_model: T0Forecaster) -> None:
+    context = np.arange(15, dtype=np.float32).reshape(3, 5)
+    forecast = tiny_model.predict(context, horizon=7)
+    assert forecast.quantiles.shape == (3, 7, 3)
+    assert forecast.median.shape == (3, 7)
+    assert forecast.quantile_levels == (0.1, 0.5, 0.9)
+    assert np.isfinite(np.asarray(forecast.quantiles)).all()
+
+
+def test_predict_accepts_one_dimensional_context(tiny_model: T0Forecaster) -> None:
+    forecast = tiny_model.predict([1.0, 2.0, 3.0], horizon=2, quantiles=[0.5])
+    assert forecast.quantiles.shape == (1, 2, 1)
+
+
+def test_predict_handles_missing_values(tiny_model: T0Forecaster) -> None:
+    forecast = tiny_model.predict(np.array([1.0, np.nan, 3.0], dtype=np.float32), horizon=2)
+    assert np.isfinite(np.asarray(forecast.quantiles)).all()
+
+
+def test_non_finite_predictions_are_replaced_and_logged(caplog: pytest.LogCaptureFixture) -> None:
+    predictions = mx.array([float("nan"), float("inf"), -float("inf"), 2.0])
+    with caplog.at_level(logging.WARNING, logger="t0_mlx.model"):
+        sanitized = _sanitize_predictions(predictions)
+
+    np.testing.assert_array_equal(np.asarray(sanitized), [0.0, 0.0, 0.0, 2.0])
+    assert "replaced 3 non-finite prediction values with 0.0" in caplog.text
+
+
+def test_forecast_interpolates_median() -> None:
+    forecast = Forecast(
+        quantiles=mx.array([[[1.0, 5.0]]], dtype=mx.float32),
+        quantile_levels=(0.1, 0.9),
+    )
+    np.testing.assert_allclose(np.asarray(forecast.median), [[3.0]])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"future_covariates": np.zeros((1, 1, 7), dtype=np.float32), "group_ids": np.array([0])}],
+)
+def test_unimplemented_structures_fail_explicitly(tiny_model: T0Forecaster, kwargs) -> None:
+    with pytest.raises(ValueError, match="cannot be combined"):
+        tiny_model.predict([1.0, 2.0, 3.0], horizon=4, **kwargs)
+
+
+def test_multivariate_context_preserves_batch_and_variate_axes(tiny_model: T0Forecaster) -> None:
+    forecast = tiny_model.predict(np.ones((2, 3, 8), dtype=np.float32), horizon=4)
+    assert forecast.quantiles.shape == (2, 3, 4, 3)
+
+
+def test_explicit_groups_are_accepted(tiny_model: T0Forecaster) -> None:
+    forecast = tiny_model.predict(
+        np.ones((4, 8), dtype=np.float32),
+        horizon=4,
+        group_ids=np.array([0, 0, 1, 2]),
+    )
+    assert forecast.quantiles.shape == (4, 4, 3)
+
+
+def test_future_covariates_are_accepted(tiny_model: T0Forecaster) -> None:
+    context = np.ones((2, 8), dtype=np.float32)
+    future = np.ones((2, 3, 12), dtype=np.float32)
+    forecast = tiny_model.predict(context, horizon=4, future_covariates=future)
+    assert forecast.quantiles.shape == (2, 4, 3)
+
+
+def test_autoregressive_rollout_extends_past_max_horizon(tiny_model: T0Forecaster) -> None:
+    tiny_model.max_horizon = 8
+    forecast = tiny_model.predict([1.0, 2.0, 3.0], horizon=12)
+    assert forecast.quantiles.shape == (1, 12, 3)
+    assert np.isfinite(np.asarray(forecast.quantiles)).all()
+
+
+def test_max_horizon_must_align_to_patch_size(tiny_model: T0Forecaster) -> None:
+    tiny_model.max_horizon = 6
+    with pytest.raises(ValueError, match="positive multiple"):
+        tiny_model.predict([1.0, 2.0, 3.0], horizon=8)
+
+
+def test_mask_cannot_mark_nan_valid(tiny_model: T0Forecaster) -> None:
+    with pytest.raises(ValueError, match="marks NaN"):
+        tiny_model.predict([1.0, np.nan, 3.0], horizon=2, mask=np.zeros(3, dtype=np.int8))
+
+
+def test_group_ids_must_match_flat_rows(tiny_model: T0Forecaster) -> None:
+    with pytest.raises(ValueError, match="one id per target row"):
+        tiny_model.predict(np.ones((2, 8), dtype=np.float32), horizon=2, group_ids=np.array([0]))
+
+
+def test_local_pretrained_round_trip(tiny_model: T0Forecaster, tmp_path) -> None:
+    tiny_model.save_pretrained(tmp_path)
+
+    restored = T0Forecaster.from_pretrained(tmp_path)
+    expected = tiny_model.predict([1.0, 2.0, 3.0], horizon=3).quantiles
+    actual = restored.predict([1.0, 2.0, 3.0], horizon=3).quantiles
+    mx.eval(expected, actual)
+    np.testing.assert_array_equal(np.asarray(actual), np.asarray(expected))
+    assert not restored.training
+    assert isinstance(restored, nn.Module)
+
+
+def test_batch_series_matches_public_contract() -> None:
+    context, mask, group_ids = batch_series(
+        [
+            np.array([1.0, 2.0, 3.0]),
+            np.array([[4.0, np.nan], [5.0, 6.0]]),
+        ]
+    )
+    assert context.shape == (3, 3)
+    np.testing.assert_array_equal(np.asarray(group_ids), [0, 1, 1])
+    np.testing.assert_array_equal(
+        np.asarray(mask),
+        [
+            [MaskType.VALID, MaskType.VALID, MaskType.VALID],
+            [MaskType.PAD, MaskType.VALID, MaskType.MISSING],
+            [MaskType.PAD, MaskType.VALID, MaskType.VALID],
+        ],
+    )
+
+
+def test_compiled_prediction_matches_eager(tiny_model: T0Forecaster) -> None:
+    context = np.arange(9, dtype=np.float32)
+    eager = tiny_model.predict(context, horizon=5).quantiles
+    compiled = tiny_model.compile().predict(context, horizon=5).quantiles
+    mx.eval(eager, compiled)
+    np.testing.assert_allclose(np.asarray(compiled), np.asarray(eager), rtol=1e-5, atol=1e-5)
+    assert tiny_model.uncompile() is tiny_model

--- a/mlx/tests/test_release.py
+++ b/mlx/tests/test_release.py
@@ -1,0 +1,59 @@
+"""Release metadata must identify one reviewed source and parity record."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).parent.parent / "tools"
+sys.path.insert(0, str(TOOLS))
+
+from release import ReleaseError, project_version, validate_release  # noqa: E402
+
+
+def _release_tree(tmp_path: Path, version: str = "1.2.3") -> Path:
+    (tmp_path / "pyproject.toml").write_text(f'[project]\nname = "example"\nversion = "{version}"\n')
+    (tmp_path / "CHANGELOG.md").write_text(f"# Changelog\n\n## [{version}] - 2026-09-03\n\n- Shipped.\n")
+    (tmp_path / "PARITY.md").write_text(f"# Numerical parity\n\n## [{version}] - 2026-09-03\n\n- Passed.\n")
+    return tmp_path
+
+
+def test_release_metadata_agrees(tmp_path: Path) -> None:
+    root = _release_tree(tmp_path)
+    version, notes = validate_release("v1.2.3", root)
+    assert version == project_version(root) == "1.2.3"
+    assert notes == "- Shipped.\n"
+
+
+@pytest.mark.parametrize(
+    ("tag", "missing", "message"),
+    [
+        ("v1.2.4", None, "release tag must be v1.2.3"),
+        ("v1.2.3", "CHANGELOG.md", "CHANGELOG.md has no"),
+        ("v1.2.3", "PARITY.md", "PARITY.md has no"),
+    ],
+)
+def test_release_metadata_rejects_mismatch(tmp_path: Path, tag: str, missing: str | None, message: str) -> None:
+    root = _release_tree(tmp_path)
+    if missing is not None:
+        (root / missing).write_text(f"# {missing}\n")
+    with pytest.raises(ReleaseError, match=message):
+        validate_release(tag, root)
+
+
+def test_monorepo_release_is_namespaced_and_tag_bound() -> None:
+    # In the public repository this test lives under mlx/tests/. In navi, the
+    # canonical source lives under apps/t0-mlx/ and the workflow is in the
+    # adjacent T0 public template.
+    candidates = (
+        Path(__file__).parents[2] / ".github/workflows/release-mlx.yml",
+        Path(__file__).parents[2] / "t0/tools/public_template/.github/workflows/release-mlx.yml",
+    )
+    workflow_path = next(path for path in candidates if path.is_file())
+    workflow = workflow_path.read_text()
+    assert 'tags: ["tfc-t0-mlx-v*"]' in workflow
+    assert "refs/tags/tfc-t0-mlx-v*" in workflow
+    assert "environment: pypi" in workflow
+    assert "working-directory: mlx" in workflow

--- a/mlx/tests/test_wheel.py
+++ b/mlx/tests/test_wheel.py
@@ -1,0 +1,48 @@
+"""Build and inspect the public wheel boundary."""
+
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).parent.parent
+
+
+@pytest.fixture(scope="module")
+def built_wheel(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    if shutil.which("uv") is None:
+        pytest.skip("uv is required to inspect the wheel")
+    output = tmp_path_factory.mktemp("wheel-build")
+    subprocess.check_call(
+        ["uv", "build", "--wheel", "--out-dir", str(output)],
+        cwd=str(PACKAGE_ROOT),
+        stdout=subprocess.DEVNULL,
+        stderr=sys.stderr,
+    )
+    wheels = list(output.glob("*.whl"))
+    assert len(wheels) == 1, wheels
+    return wheels[0]
+
+
+def test_wheel_contains_only_package_and_metadata(built_wheel: Path) -> None:
+    with zipfile.ZipFile(built_wheel) as archive:
+        names = archive.namelist()
+    unexpected = [name for name in names if not (name.startswith("t0_mlx/") or ".dist-info/" in name)]
+    assert not unexpected, unexpected
+
+
+def test_wheel_includes_legal_files(built_wheel: Path) -> None:
+    with zipfile.ZipFile(built_wheel) as archive:
+        names = archive.namelist()
+    assert any(name.endswith("/LICENSE") for name in names)
+    assert any(name.endswith("/NOTICE") for name in names)
+
+
+def test_wheel_excludes_public_repository_support_files(built_wheel: Path) -> None:
+    with zipfile.ZipFile(built_wheel) as archive:
+        names = archive.namelist()
+    forbidden = ("tests/", "tools/", "README.INTERNAL.md", "BENCHMARKS.md", "PARITY.md", "CHANGELOG.md")
+    assert not [name for name in names if name.startswith(forbidden) or Path(name).name in forbidden]

--- a/mlx/tools/benchmark.py
+++ b/mlx/tools/benchmark.py
@@ -1,0 +1,465 @@
+"""Compare t0-alpha inference across MLX, PyTorch MPS, and PyTorch CPU."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.metadata
+import json
+import statistics
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+BACKENDS = ("mlx-eager", "mlx-compiled", "torch-mps", "torch-cpu")
+RESULT_MARKER = "T0_BENCHMARK_RESULT="
+DEFAULT_WORKLOADS = ((1, 96, 32), (1, 512, 64), (8, 96, 32))
+
+
+@dataclass(frozen=True)
+class Workload:
+    """One public-API forecast shape."""
+
+    batch: int
+    context: int
+    horizon: int
+
+    @property
+    def label(self) -> str:
+        return f"batch {self.batch}, context {self.context}, horizon {self.horizon}"
+
+
+@dataclass(frozen=True)
+class Timing:
+    """Synchronized steady-state latency for one backend and workload."""
+
+    backend: str
+    workload: Workload
+    minimum_ms: float
+    median_ms: float
+    maximum_ms: float
+    checksum: float
+    output_shape: tuple[int, ...]
+    output: list[float]
+    compile_and_first_run_ms: float | None = None
+
+
+@dataclass(frozen=True)
+class NumericalComparison:
+    """Elementwise agreement with the PyTorch CPU reference output."""
+
+    backend: str
+    workload: Workload
+    max_abs_error: float
+    max_rel_error: float
+    within_tolerance: bool
+
+
+def _parse_workload(value: str) -> Workload:
+    try:
+        batch, context, horizon = (int(part) for part in value.split(","))
+    except (TypeError, ValueError) as error:
+        raise argparse.ArgumentTypeError("workload must be BATCH,CONTEXT,HORIZON") from error
+    if batch < 1 or context < 1 or horizon < 1:
+        raise argparse.ArgumentTypeError("workload dimensions must be positive")
+    return Workload(batch, context, horizon)
+
+
+def _measure(
+    predict: Callable[[], Any],
+    synchronize: Callable[[Any], None],
+    to_numpy: Callable[[Any], np.ndarray],
+    iterations: int,
+) -> tuple[float, float, float, np.ndarray]:
+    durations: list[float] = []
+    forecast: Any = None
+    for _ in range(iterations):
+        synchronize(None)
+        started = time.perf_counter()
+        forecast = predict()
+        synchronize(forecast)
+        durations.append((time.perf_counter() - started) * 1000.0)
+    values = to_numpy(forecast)
+    return min(durations), statistics.median(durations), max(durations), values
+
+
+def _benchmark_mlx(
+    backend: str,
+    checkpoint: Path,
+    workloads: Sequence[Workload],
+    warmup: int,
+    iterations: int,
+    seed: int,
+) -> dict[str, Any]:
+    import mlx.core as mx
+
+    from t0_mlx import T0Forecaster
+
+    model = T0Forecaster.from_pretrained(checkpoint)
+    compiled = backend == "mlx-compiled"
+    if compiled:
+        model.compile()
+
+    timings = []
+    for workload in workloads:
+        context = np.random.default_rng(seed).normal(size=(workload.batch, workload.context)).astype(np.float32)
+        predict = partial(model.predict, context, horizon=workload.horizon)
+
+        compile_and_first_run_ms = None
+        if compiled:
+            started = time.perf_counter()
+            first = predict()
+            mx.eval(first.quantiles)
+            compile_and_first_run_ms = (time.perf_counter() - started) * 1000.0
+
+        for _ in range(warmup):
+            warm = predict()
+            mx.eval(warm.quantiles)
+
+        minimum, median, maximum, output = _measure(
+            predict,
+            lambda forecast: mx.synchronize() if forecast is None else mx.eval(forecast.quantiles),
+            lambda forecast: np.asarray(forecast.quantiles),
+            iterations,
+        )
+        timings.append(
+            Timing(
+                backend=backend,
+                workload=workload,
+                minimum_ms=minimum,
+                median_ms=median,
+                maximum_ms=maximum,
+                checksum=float(output.sum()),
+                output_shape=output.shape,
+                output=output.reshape(-1).tolist(),
+                compile_and_first_run_ms=compile_and_first_run_ms,
+            )
+        )
+
+    return {
+        "backend": backend,
+        "framework": f"MLX {importlib.metadata.version('mlx')}",
+        "device": str(mx.default_device()),
+        "timings": [_timing_to_dict(timing) for timing in timings],
+    }
+
+
+def _benchmark_torch(
+    backend: str,
+    checkpoint: Path,
+    workloads: Sequence[Workload],
+    warmup: int,
+    iterations: int,
+    seed: int,
+    torch_threads: int | None,
+) -> dict[str, Any]:
+    try:
+        t0 = importlib.import_module("t0")
+        import torch  # ty: ignore[unresolved-import]
+    except ImportError as error:
+        raise RuntimeError(
+            "PyTorch benchmarks require the parity extra (`uv run --extra parity ...`) "
+            "or the local tfc-t0 checkout (`uv run --with-editable .. ...`)."
+        ) from error
+
+    device = "mps" if backend == "torch-mps" else "cpu"
+    if device == "mps" and not torch.backends.mps.is_available():
+        raise RuntimeError("PyTorch MPS is not available on this machine")
+    if torch_threads is not None:
+        torch.set_num_threads(torch_threads)
+
+    model = t0.T0Forecaster.from_pretrained(checkpoint).eval().to(device)
+    synchronize = torch.mps.synchronize if device == "mps" else lambda: None
+    timings = []
+    for workload in workloads:
+        context = np.random.default_rng(seed).normal(size=(workload.batch, workload.context)).astype(np.float32)
+        predict = partial(model.predict, context, horizon=workload.horizon)
+        for _ in range(warmup):
+            predict()
+        synchronize()
+
+        minimum, median, maximum, output = _measure(
+            predict,
+            lambda _forecast: synchronize(),
+            lambda forecast: forecast.quantiles.detach().cpu().numpy(),
+            iterations,
+        )
+        timings.append(
+            Timing(
+                backend=backend,
+                workload=workload,
+                minimum_ms=minimum,
+                median_ms=median,
+                maximum_ms=maximum,
+                checksum=float(output.sum()),
+                output_shape=output.shape,
+                output=output.reshape(-1).tolist(),
+            )
+        )
+
+    return {
+        "backend": backend,
+        "framework": f"PyTorch {torch.__version__}",
+        "device": device,
+        "torch_threads": torch.get_num_threads(),
+        "timings": [_timing_to_dict(timing) for timing in timings],
+    }
+
+
+def _timing_to_dict(timing: Timing) -> dict[str, Any]:
+    value = asdict(timing)
+    value["workload"] = asdict(timing.workload)
+    return value
+
+
+def _workload_key(timing: dict[str, Any]) -> tuple[int, int, int]:
+    workload = timing["workload"]
+    return workload["batch"], workload["context"], workload["horizon"]
+
+
+def _compare_with_torch_cpu(
+    results: Sequence[dict[str, Any]],
+    *,
+    rtol: float,
+    atol: float,
+) -> list[NumericalComparison]:
+    """Compare every available backend elementwise with PyTorch CPU."""
+    by_backend = {result["backend"]: result for result in results}
+    reference = by_backend.get("torch-cpu")
+    if reference is None:
+        return []
+    reference_timings = {_workload_key(timing): timing for timing in reference["timings"]}
+    comparisons: list[NumericalComparison] = []
+    for result in results:
+        if result["backend"] == "torch-cpu":
+            continue
+        for timing in result["timings"]:
+            key = _workload_key(timing)
+            reference_timing = reference_timings[key]
+            expected = np.asarray(reference_timing["output"], dtype=np.float32).reshape(
+                reference_timing["output_shape"]
+            )
+            actual = np.asarray(timing["output"], dtype=np.float32).reshape(timing["output_shape"])
+            if actual.shape != expected.shape:
+                raise RuntimeError(
+                    f"{result['backend']} returned {actual.shape} for {key}; PyTorch CPU returned {expected.shape}"
+                )
+            absolute = np.abs(actual - expected)
+            relative = absolute / np.maximum(np.abs(expected), np.float32(1e-6))
+            comparisons.append(
+                NumericalComparison(
+                    backend=result["backend"],
+                    workload=Workload(*key),
+                    max_abs_error=float(absolute.max(initial=0.0)),
+                    max_rel_error=float(relative.max(initial=0.0)),
+                    within_tolerance=bool(np.all(absolute <= atol + rtol * np.abs(expected))),
+                )
+            )
+    return comparisons
+
+
+def _remove_raw_outputs(results: Sequence[dict[str, Any]]) -> None:
+    for result in results:
+        for timing in result["timings"]:
+            timing.pop("output", None)
+            timing.pop("output_shape", None)
+
+
+def _run_worker(args: argparse.Namespace) -> None:
+    if args.backend.startswith("mlx-"):
+        result = _benchmark_mlx(
+            args.backend,
+            args.checkpoint,
+            args.workloads,
+            args.warmup,
+            args.iterations,
+            args.seed,
+        )
+    else:
+        result = _benchmark_torch(
+            args.backend,
+            args.checkpoint,
+            args.workloads,
+            args.warmup,
+            args.iterations,
+            args.seed,
+            args.torch_threads,
+        )
+    print(f"{RESULT_MARKER}{json.dumps(result, separators=(',', ':'))}")
+
+
+def _worker_command(args: argparse.Namespace, backend: str) -> list[str]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        str(args.checkpoint),
+        "--backend",
+        backend,
+        "--warmup",
+        str(args.warmup),
+        "--iterations",
+        str(args.iterations),
+        "--seed",
+        str(args.seed),
+        "--worker",
+    ]
+    for workload in args.workloads:
+        command.extend(["--workload", f"{workload.batch},{workload.context},{workload.horizon}"])
+    if args.torch_threads is not None:
+        command.extend(["--torch-threads", str(args.torch_threads)])
+    return command
+
+
+def _run_isolated(args: argparse.Namespace, backend: str) -> dict[str, Any]:
+    completed = subprocess.run(_worker_command(args, backend), check=False, capture_output=True, text=True)
+    if completed.returncode != 0:
+        sys.stderr.write(completed.stdout)
+        sys.stderr.write(completed.stderr)
+        raise SystemExit(completed.returncode)
+    for line in reversed(completed.stdout.splitlines()):
+        if line.startswith(RESULT_MARKER):
+            return json.loads(line.removeprefix(RESULT_MARKER))
+    raise RuntimeError(f"benchmark worker {backend!r} returned no result")
+
+
+def _render_markdown(
+    results: Sequence[dict[str, Any]],
+    comparisons: Sequence[NumericalComparison],
+    *,
+    warmup: int,
+    iterations: int,
+    seed: int,
+    rtol: float,
+    atol: float,
+) -> str:
+    frameworks = []
+    for result in results:
+        description = f"{result['framework']} on {result['device']}"
+        if "torch_threads" in result:
+            description += f" ({result['torch_threads']} CPU threads)"
+        if description not in frameworks:
+            frameworks.append(description)
+    rows = [
+        f"Python {sys.version.split()[0]}; {warmup} warm-ups; {iterations} timed calls; seed {seed}.",
+        "Frameworks: " + "; ".join(frameworks) + ".",
+        "",
+        "| Backend | Shape | Minimum | Median | Maximum | Compile + first run | Checksum |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for result in results:
+        for timing in result["timings"]:
+            workload = timing["workload"]
+            shape = f"batch {workload['batch']}, context {workload['context']}, horizon {workload['horizon']}"
+            first = timing["compile_and_first_run_ms"]
+            first_text = "—" if first is None else f"{first:.2f} ms"
+            rows.append(
+                f"| {timing['backend']} | {shape} | {timing['minimum_ms']:.2f} ms "
+                f"| {timing['median_ms']:.2f} ms | {timing['maximum_ms']:.2f} ms "
+                f"| {first_text} | {timing['checksum']:.6f} |"
+            )
+    if comparisons:
+        rows.extend(
+            [
+                "",
+                f"Elementwise output comparison with PyTorch CPU (`rtol={rtol:g}`, `atol={atol:g}`):",
+                "",
+                "| Backend | Shape | Maximum absolute error | Maximum relative error | Within tolerance |",
+                "| --- | --- | ---: | ---: | ---: |",
+            ]
+        )
+        for comparison in comparisons:
+            rows.append(
+                f"| {comparison.backend} | {comparison.workload.label} "
+                f"| {comparison.max_abs_error:.3e} | {comparison.max_rel_error:.3e} "
+                f"| {'yes' if comparison.within_tolerance else 'NO'} |"
+            )
+    return "\n".join(rows)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("checkpoint", type=Path, help="directory containing config.json and model.safetensors")
+    parser.add_argument("--backend", choices=("all", *BACKENDS), default="all")
+    parser.add_argument(
+        "--workload",
+        dest="workloads",
+        action="append",
+        type=_parse_workload,
+        help="repeatable BATCH,CONTEXT,HORIZON tuple; defaults to three representative shapes",
+    )
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=60)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--torch-threads", type=int)
+    parser.add_argument("--parity-rtol", type=float, default=2e-5)
+    parser.add_argument("--parity-atol", type=float, default=3e-4)
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    args.workloads = args.workloads or [Workload(*values) for values in DEFAULT_WORKLOADS]
+    if args.warmup < 0:
+        raise SystemExit("--warmup must be non-negative")
+    if args.iterations < 1:
+        raise SystemExit("--iterations must be positive")
+    if args.torch_threads is not None and args.torch_threads < 1:
+        raise SystemExit("--torch-threads must be positive")
+    if args.parity_rtol < 0 or args.parity_atol < 0:
+        raise SystemExit("--parity-rtol and --parity-atol must be non-negative")
+    if not (args.checkpoint / "config.json").is_file() or not (args.checkpoint / "model.safetensors").is_file():
+        raise SystemExit(f"{args.checkpoint} must contain config.json and model.safetensors")
+
+    if args.worker:
+        if args.backend == "all":
+            raise SystemExit("worker mode requires one concrete backend")
+        _run_worker(args)
+        return
+
+    backends = BACKENDS if args.backend == "all" else (args.backend,)
+    results = [_run_isolated(args, backend) for backend in backends]
+    comparisons = _compare_with_torch_cpu(results, rtol=args.parity_rtol, atol=args.parity_atol)
+    _remove_raw_outputs(results)
+    payload = {
+        "python": sys.version.split()[0],
+        "warmup": args.warmup,
+        "iterations": args.iterations,
+        "seed": args.seed,
+        "parity_rtol": args.parity_rtol,
+        "parity_atol": args.parity_atol,
+        "backends": results,
+        "comparisons": [
+            {**asdict(comparison), "workload": asdict(comparison.workload)} for comparison in comparisons
+        ],
+    }
+    if args.format == "json":
+        print(json.dumps(payload, indent=2))
+    else:
+        print(
+            _render_markdown(
+                results,
+                comparisons,
+                warmup=args.warmup,
+                iterations=args.iterations,
+                seed=args.seed,
+                rtol=args.parity_rtol,
+                atol=args.parity_atol,
+            )
+        )
+    failed = [comparison for comparison in comparisons if not comparison.within_tolerance]
+    if failed:
+        backends = ", ".join(sorted({comparison.backend for comparison in failed}))
+        raise SystemExit(f"elementwise comparison with PyTorch CPU failed for: {backends}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx/tools/release.py
+++ b/mlx/tools/release.py
@@ -1,0 +1,72 @@
+"""Validate release metadata and extract notes for a tagged release."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+VERSION_PATTERN = re.compile(r'^version\s*=\s*"([^"]+)"\s*$')
+
+
+class ReleaseError(RuntimeError):
+    """Raised when a release tag and the checked-out source disagree."""
+
+
+def project_version(root: Path = PACKAGE_ROOT) -> str:
+    """Read ``project.version`` from the package's intentionally simple TOML."""
+    in_project = False
+    for line in (root / "pyproject.toml").read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_project = stripped == "[project]"
+            continue
+        if in_project and (match := VERSION_PATTERN.fullmatch(stripped)):
+            return match.group(1)
+    raise ReleaseError("pyproject.toml has no project.version")
+
+
+def _section(path: Path, version: str) -> str:
+    """Return the non-empty Markdown section headed by ``version``."""
+    prefix = f"## [{version}]"
+    lines = path.read_text().splitlines()
+    start = next((index + 1 for index, line in enumerate(lines) if line.startswith(prefix)), None)
+    if start is None:
+        raise ReleaseError(f"{path.name} has no {prefix} section")
+    stop = next((index for index in range(start, len(lines)) if lines[index].startswith("## [")), len(lines))
+    section = "\n".join(lines[start:stop]).strip()
+    if not section:
+        raise ReleaseError(f"{path.name} has an empty {prefix} section")
+    return section + "\n"
+
+
+def validate_release(tag: str, root: Path = PACKAGE_ROOT) -> tuple[str, str]:
+    """Require tag, package version, changelog, and parity record to agree."""
+    version = project_version(root)
+    expected_tag = f"v{version}"
+    if tag != expected_tag:
+        raise ReleaseError(f"release tag must be {expected_tag}, got {tag}")
+    notes = _section(root / "CHANGELOG.md", version)
+    _section(root / "PARITY.md", version)
+    return version, notes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag", help="annotated release tag, for example v0.1.0a0")
+    parser.add_argument("--root", type=Path, default=PACKAGE_ROOT, help=argparse.SUPPRESS)
+    parser.add_argument("--notes-output", type=Path, help="write the matching changelog section here")
+    args = parser.parse_args()
+
+    try:
+        version, notes = validate_release(args.tag, args.root)
+    except (OSError, ReleaseError) as error:
+        raise SystemExit(f"release validation failed: {error}") from error
+    if args.notes_output is not None:
+        args.notes_output.write_text(notes)
+    print(f"validated release {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx/tools/validate_checkpoint.py
+++ b/mlx/tools/validate_checkpoint.py
@@ -1,0 +1,60 @@
+"""Validate that the original t0-alpha checkpoint loads directly in MLX."""
+
+import argparse
+import hashlib
+from pathlib import Path
+from typing import cast
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+from t0_mlx import T0Config, T0Forecaster
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def validate_checkpoint(source: Path) -> tuple[T0Config, str]:
+    """Verify that every checkpoint tensor matches the MLX parameter tree."""
+    config_path = source / "config.json"
+    weights_path = source / "model.safetensors"
+    if not config_path.is_file() or not weights_path.is_file():
+        raise FileNotFoundError(f"{source} must contain config.json and model.safetensors")
+
+    config = T0Config.from_json(config_path)
+    expected = dict(tree_flatten(T0Forecaster.from_config(config).parameters()))
+    loaded = mx.load(str(weights_path))
+    if not isinstance(loaded, dict):
+        raise ValueError("expected model.safetensors to contain a named tensor mapping")
+    actual = cast(dict[str, mx.array], loaded)
+    if set(expected) != set(actual):
+        missing = sorted(set(expected) - set(actual))
+        unexpected = sorted(set(actual) - set(expected))
+        raise ValueError(f"checkpoint key mismatch: missing={missing}, unexpected={unexpected}")
+    mismatched = {
+        key: (expected[key].shape, actual[key].shape) for key in expected if expected[key].shape != actual[key].shape
+    }
+    if mismatched:
+        raise ValueError(f"checkpoint shape mismatch: {mismatched}")
+    non_fp32 = sorted(key for key, value in actual.items() if value.dtype != mx.float32)
+    if non_fp32:
+        raise ValueError(f"expected an FP32 checkpoint; other dtypes found at {non_fp32}")
+    return config, _sha256(weights_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("checkpoint", type=Path, help="directory containing the original checkpoint")
+    args = parser.parse_args()
+
+    config, digest = validate_checkpoint(args.checkpoint)
+    print(f"validated {config.num_layers} layers; model.safetensors sha256={digest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,10 @@ build-backend = "hatchling.build"
 # LICENSE + NOTICE are picked up automatically via [project.license-files].
 packages = ["t0"]
 
+[tool.hatch.build.targets.sdist]
+# The MLX runtime is a separate distribution built from mlx/pyproject.toml.
+exclude = ["/mlx"]
+
 [tool.ruff]
 line-length = 120
 target-version = "py310"


### PR DESCRIPTION
## Summary

- add the first-party MLX implementation under `mlx/`
- keep `tfc-t0` and `tfc-t0-mlx` as separate PyPI distributions with independent dependencies
- link both runtimes from the main README so this repository is their single discovery and contribution surface
- add path-scoped MLX CI and a separate release workflow triggered only by annotated `tfc-t0-mlx-v*` tags
- exclude `mlx/` from the `tfc-t0` source distribution

The public tree is generated by companion Navi PR #1975, which updates the allowlisted mirror so future syncs preserve both runtimes.

## Validation

- PyTorch Ruff and import smoke pass
- MLX tests: 37 passed, 4 skipped on Python 3.12
- MLX Ruff and ty pass
- `tfc-t0` and `tfc-t0-mlx` wheels and sdists build independently
- Twine 7.0.0 accepts all four distributions
- confirmed the `tfc-t0` sdist contains no `mlx/` subtree
- generated public surface passes the Navi leak scan

## Release note

This PR does not publish either package or create a tag. Before the first MLX release here, the PyPI trusted publisher for `tfc-t0-mlx` must be changed to repository `tfc-t0`, workflow `release-mlx.yml`, environment `pypi`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/theforecastingcompany/codesmith/tfc-t0/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791137134&installation_model_id=12780&pr_number=8&repository=theforecastingcompany%2Ftfc-t0&return_to=https%3A%2F%2Fgithub.com%2Ftheforecastingcompany%2Ftfc-t0%2Fpull%2F8&signature=6abf0fdb0367c8b5925ed06bdf4e38e63e824f5c53df45c96af5052273fca40b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the first-party MLX runtime for `t0-alpha` as `tfc-t0-mlx`, a separate PyPI distribution, so Apple silicon users get MLX-native inference without the PyTorch dependency stack. The `tfc-t0` sdist now excludes `mlx/`, and the main README links both runtimes.

**MLX runtime**
- Native MLX implementation that loads the original checkpoint directly and covers the full forecasting API: multivariate series, masks, grouping, known-future covariates, quantile interpolation, and autoregressive rollout.
- Opt-in compilation for repeated input shapes.
- Checkpoint-backed FP32 parity tests plus reproducible benchmarks against PyTorch MPS and CPU.

**Release notes**
- Path-scoped MLX CI runs on macOS for Python 3.10, 3.12, and 3.14; `release-mlx.yml` publishes only from annotated `tfc-t0-mlx-v*` tags.
- This PR does not publish either package or create a tag; change the PyPI trusted publisher for `tfc-t0-mlx` to repository `tfc-t0`, workflow `release-mlx.yml`, environment `pypi` before the first release.
- The public mirror sync relies on companion Navi work that updates the allowlisted mirror to preserve both runtimes.

<sup>Written for commit 772969c6a784ab104a0a84f37e25163856c2fc3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/theforecastingcompany/tfc-t0/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

