### PR TITLE
docs: explain authentication in the t0-alpha quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `tfc-t0` are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Preserve Hugging Face configuration-download errors in `from_pretrained`,
+  including gated-model access failures, instead of reporting missing model
+  constructor arguments.
+- Document the model-access and authentication steps before the PyTorch
+  quickstart in the README and model card.
+
 ## [0.3.1] - 2026-09-01
 
 Documentation-only release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
-- Preserve Hugging Face configuration-download errors in `from_pretrained`,
-  including gated-model access failures, instead of reporting missing model
-  constructor arguments.
 - Document the model-access and authentication steps before the PyTorch
   quickstart in the README and model card.
 

--- a/README.md
+++ b/README.md
@@ -65,13 +65,26 @@ historical and known-future covariates.
 pip install tfc-t0
 ```
 
+The model repository is gated. Before the first download, sign in to
+[the model page](https://huggingface.co/theforecastingcompany/t0-alpha) and
+accept its access conditions. Then authenticate with a token from that same
+account that can read the model:
+
+```bash
+hf auth login
+```
+
+In a notebook, use `from huggingface_hub import login; login()` instead.
+For scripts and CI, set `HF_TOKEN` in the environment. Signing in to the
+website alone does not authenticate your Python environment.
+
 The simplest path is a univariate forecast through `predict`:
 
 ```python
 import torch
 from t0 import T0Forecaster
 
-model = T0Forecaster.from_pretrained("theforecastingcompany/t0-alpha").eval()
+model = T0Forecaster.from_pretrained("theforecastingcompany/t0-alpha", token=True).eval()
 
 context = torch.randn(4, 512)  # 4 series, 512 past timesteps
 out = model.predict(context, horizon=64, quantiles=[0.1, 0.5, 0.9])

--- a/t0/model/model.py
+++ b/t0/model/model.py
@@ -11,11 +11,13 @@ import dataclasses
 import logging
 import sys
 from collections.abc import Sequence
+from pathlib import Path
 
 import numpy as np
 import torch
 import torch.nn as nn
-from huggingface_hub import PyTorchModelHubMixin
+from huggingface_hub import PyTorchModelHubMixin, hf_hub_download
+from huggingface_hub.constants import CONFIG_NAME
 from jaxtyping import Float, Int
 from torch import Tensor
 
@@ -145,6 +147,47 @@ class T0Forecaster(
         # bf16/fp16 autocast the forward in predict() (weights stay fp32);
         # anything else runs in fp32.
         self._amp_dtype: torch.dtype | None = dtype if dtype in (torch.float16, torch.bfloat16) else None
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str | Path,
+        *,
+        revision: str | None = None,
+        force_download: bool = False,
+        token: str | bool | None = None,
+        cache_dir: str | Path | None = None,
+        local_files_only: bool = False,
+        **model_kwargs: object,
+    ) -> Self:
+        """Load a checkpoint, preserving errors when its Hub config is inaccessible.
+
+        For gated models, accept the model's access conditions and authenticate
+        with ``hf auth login`` or pass ``token``. Local directories and cached
+        checkpoints remain usable without network access.
+        """
+        if not Path(pretrained_model_name_or_path).is_dir():
+            # The Hub mixin treats config HTTP errors as an optional missing file.
+            # T0 requires its architecture config: check access first so a denied
+            # download raises the original error rather than a constructor TypeError.
+            hf_hub_download(
+                str(pretrained_model_name_or_path),
+                CONFIG_NAME,
+                revision=revision,
+                force_download=force_download,
+                token=token,
+                cache_dir=cache_dir,
+                local_files_only=local_files_only,
+            )
+        return super().from_pretrained(
+            pretrained_model_name_or_path,
+            revision=revision,
+            force_download=force_download,
+            token=token,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+            **model_kwargs,
+        )
 
     @classmethod
     def from_config(cls, config: T0Config) -> Self:

--- a/t0/model/model.py
+++ b/t0/model/model.py
@@ -11,13 +11,11 @@ import dataclasses
 import logging
 import sys
 from collections.abc import Sequence
-from pathlib import Path
 
 import numpy as np
 import torch
 import torch.nn as nn
-from huggingface_hub import PyTorchModelHubMixin, hf_hub_download
-from huggingface_hub.constants import CONFIG_NAME
+from huggingface_hub import PyTorchModelHubMixin
 from jaxtyping import Float, Int
 from torch import Tensor
 
@@ -147,47 +145,6 @@ class T0Forecaster(
         # bf16/fp16 autocast the forward in predict() (weights stay fp32);
         # anything else runs in fp32.
         self._amp_dtype: torch.dtype | None = dtype if dtype in (torch.float16, torch.bfloat16) else None
-
-    @classmethod
-    def from_pretrained(
-        cls,
-        pretrained_model_name_or_path: str | Path,
-        *,
-        revision: str | None = None,
-        force_download: bool = False,
-        token: str | bool | None = None,
-        cache_dir: str | Path | None = None,
-        local_files_only: bool = False,
-        **model_kwargs: object,
-    ) -> Self:
-        """Load a checkpoint, preserving errors when its Hub config is inaccessible.
-
-        For gated models, accept the model's access conditions and authenticate
-        with ``hf auth login`` or pass ``token``. Local directories and cached
-        checkpoints remain usable without network access.
-        """
-        if not Path(pretrained_model_name_or_path).is_dir():
-            # The Hub mixin treats config HTTP errors as an optional missing file.
-            # T0 requires its architecture config: check access first so a denied
-            # download raises the original error rather than a constructor TypeError.
-            hf_hub_download(
-                str(pretrained_model_name_or_path),
-                CONFIG_NAME,
-                revision=revision,
-                force_download=force_download,
-                token=token,
-                cache_dir=cache_dir,
-                local_files_only=local_files_only,
-            )
-        return super().from_pretrained(
-            pretrained_model_name_or_path,
-            revision=revision,
-            force_download=force_download,
-            token=token,
-            cache_dir=cache_dir,
-            local_files_only=local_files_only,
-            **model_kwargs,
-        )
 
     @classmethod
     def from_config(cls, config: T0Config) -> Self:


### PR DESCRIPTION
The quickstart assumes Hugging Face credentials are already available. Document accepting the model access conditions and authenticating with `hf auth login`, notebook `login()`, or `HF_TOKEN`. Use `token=True` in the first example so a missing token produces the existing login guidance rather than a confusing constructor error.

This changes only the README and changelog and works with the current package release.

Validation: with the original loader, an empty token lookup raises `LocalTokenNotFoundError`; the authenticated example produces finite quantiles `(4, 64, 3)` and median `(4, 64)`. Runtime code is unchanged.
